### PR TITLE
feat: migrate API server to ES modules

### DIFF
--- a/api/config/mongo.js
+++ b/api/config/mongo.js
@@ -1,4 +1,5 @@
-const mongoose = require('mongoose')
+import mongoose from 'mongoose'
+
 const connectDB = async () => {
     try {
         const connection = await mongoose.connect(process.env.MONGODB_URI)
@@ -9,4 +10,5 @@ const connectDB = async () => {
         process.exit(1) // 1 indicates an unspecified error
     }
 }
-module.exports = connectDB
+
+export default connectDB

--- a/api/controllers/exampleController.js
+++ b/api/controllers/exampleController.js
@@ -2,7 +2,7 @@
 
 // ==============================|| Controler - Example ||============================== //
 
-module.exports = {
+export default {
     // @desc        
     // @route       GET /get-example
     // @access      Public
@@ -11,7 +11,7 @@ module.exports = {
         } catch (error) {            
         }
     },
-}
+};
 
 
 

--- a/api/index.js
+++ b/api/index.js
@@ -1,12 +1,15 @@
-const cors = require('cors');
-const path = require('path')
-const express = require('express');
-const dotenv = require('dotenv')
-const morgan = require('morgan')
-const connectDB = require('./config/mongo')
+import cors from 'cors';
+import path from 'path';
+import express from 'express';
+import dotenv from 'dotenv';
+import morgan from 'morgan';
+import { fileURLToPath } from 'url';
+
+import connectDB from './config/mongo.js';
+import router from './routes/index.js';
 
 dotenv.config();
-connectDB()
+connectDB();
 
 const app = express();
 
@@ -23,24 +26,28 @@ const corsOptionsDelegate = function (req, callback) {
 app.use(cors(corsOptionsDelegate));
 
 // --------------- BODY PARSER MIDDLEWARE ---------------- //
-app.use(express.urlencoded( {extended: false}))
+app.use(express.urlencoded({ extended: false }));
 app.use(express.json());
 
 // ----------------- LOGGING MIDDLEWARE ------------------ //
 if (process.env.NODE_ENV === 'development') {
-    app.use(morgan('dev'))
+    app.use(morgan('dev'));
 }
 
 // -------------------- Static Assets -------------------- //
-app.use(express.static(path.join(__dirname, 'public')) )
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
 
+app.use(express.static(path.join(__dirname, 'public')));
 
 // ------------------------ Routes ----------------------- //
-app.use('/', require('./routes/index'))
+app.use('/', router);
 
-const PORT = process.env.PORT || 3000
+const PORT = process.env.PORT || 3000;
 app.listen(
-    PORT, () => console.log(`Server running in ${process.env.NODE_ENV} mode, on port ${PORT}`)
-)
+    PORT,
+    () => console.log(`Server running in ${process.env.NODE_ENV} mode, on port ${PORT}`)
+);
 
-module.exports = app;
+export default app;
+

--- a/api/package.json
+++ b/api/package.json
@@ -2,6 +2,7 @@
   "name": "api",
   "version": "1.0.0",
   "description": "",
+  "type": "module",
   "main": "index.js",
   "scripts": {
     "start": "cross-env NODE_ENV=production node index.js",

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,10 +1,11 @@
-const express = require('express')
+import express from 'express'
+import exampleController from "../controllers/exampleController.js";
+
 const router = express.Router()
-const exampleController = require("../controllers/exampleController");
 
 // ==============================|| Routes - Index ||============================== //
 
 
 router.get('/get-example', exampleController.getExample);
 
-module.exports = router
+export default router


### PR DESCRIPTION
## Summary
- convert API codebase from CommonJS to ES modules
- enable ESM support via package.json and update imports/exports
- use fileURLToPath for __dirname resolution

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_689a7aa5912c8320872e869ae660e6b0