### PR TITLE
feat: log add-in text via local API

### DIFF
--- a/api/controllers/logController.js
+++ b/api/controllers/logController.js
@@ -1,0 +1,15 @@
+import asyncHandler from '../middleware/asyncHandler.js';
+
+// ==============================|| Controller - Log ||============================== //
+
+export default {
+    // @desc       Log posted text
+    // @route      POST /log-text
+    // @access     Public
+    logText: asyncHandler(async (req, res) => {
+        const { text } = req.body;
+        console.log('Received text:', text);
+        res.status(200).json({ message: 'Text logged' });
+    }),
+};
+

--- a/api/index.js
+++ b/api/index.js
@@ -47,7 +47,7 @@ app.use('/', router);
 app.use(notFound);
 app.use(errorHandler);
 
-const PORT = process.env.PORT || 3000;
+const PORT = process.env.PORT || 4000;
 app.listen(
     PORT,
     () => console.log(`Server running in ${process.env.NODE_ENV} mode, on port ${PORT}`)

--- a/api/routes/index.js
+++ b/api/routes/index.js
@@ -1,5 +1,6 @@
 import express from 'express'
 import exampleController from "../controllers/exampleController.js";
+import logController from "../controllers/logController.js";
 
 const router = express.Router()
 
@@ -7,5 +8,6 @@ const router = express.Router()
 
 
 router.get('/get-example', exampleController.getExample);
+router.post('/log-text', logController.logText);
 
 export default router

--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -4,7 +4,7 @@ import HeroList, { HeroListItem } from "./HeroList";
 import TextInsertion from "./TextInsertion";
 import { makeStyles } from "@fluentui/react-components";
 import { Ribbon24Regular, LockOpen24Regular, DesignIdeas24Regular } from "@fluentui/react-icons";
-import { insertText } from "../taskpane";
+import { sendText } from "../taskpane";
 
 interface AppProps {
   title: string;
@@ -39,7 +39,7 @@ const App: React.FC<AppProps> = (props: AppProps) => {
     <div className={styles.root}>
       <Header logo="assets/logo-filled.png" title={props.title} message="Welcome" />
       <HeroList message="Discover what this add-in can do for you today!" items={listItems} />
-      <TextInsertion insertText={insertText} />
+        <TextInsertion sendText={sendText} />
     </div>
   );
 };

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -5,7 +5,7 @@ import { Button, Field, Textarea, tokens, makeStyles } from "@fluentui/react-com
 /* global HTMLTextAreaElement */
 
 interface TextInsertionProps {
-  insertText: (text: string) => void;
+  sendText: (text: string) => void;
 }
 
 const useStyles = makeStyles({
@@ -31,9 +31,9 @@ const useStyles = makeStyles({
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
   const [text, setText] = useState<string>("Some text.");
 
-  const handleTextInsertion = async () => {
-    await props.insertText(text);
-  };
+    const handleTextSend = async () => {
+      await props.sendText(text);
+    };
 
   const handleTextChange = async (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     setText(event.target.value);
@@ -43,13 +43,13 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
 
   return (
     <div className={styles.textPromptAndInsertion}>
-      <Field className={styles.textAreaField} size="large" label="Enter text to be inserted into the document.">
-        <Textarea size="large" value={text} onChange={handleTextChange} />
-      </Field>
-      <Field className={styles.instructions}>Click the button to insert text.</Field>
-      <Button appearance="primary" disabled={false} size="large" onClick={handleTextInsertion}>
-        Insert text
-      </Button>
+        <Field className={styles.textAreaField} size="large" label="Enter text to send to the API.">
+          <Textarea size="large" value={text} onChange={handleTextChange} />
+        </Field>
+        <Field className={styles.instructions}>Click the button to send text.</Field>
+        <Button appearance="primary" disabled={false} size="large" onClick={handleTextSend}>
+          Send text
+        </Button>
     </div>
   );
 };

--- a/ui/src/taskpane/taskpane.ts
+++ b/ui/src/taskpane/taskpane.ts
@@ -1,18 +1,14 @@
-/* global Office console */
+/* global console */
 
-export async function insertText(text: string) {
-  // Write text to the cursor point in the compose surface.
+export async function sendText(text: string) {
   try {
-    Office.context.mailbox.item?.body.setSelectedDataAsync(
-      text,
-      { coercionType: Office.CoercionType.Text },
-      (asyncResult: Office.AsyncResult<void>) => {
-        if (asyncResult.status === Office.AsyncResultStatus.Failed) {
-          throw asyncResult.error.message;
-        }
-      }
-    );
+    await fetch('http://localhost:4000/log-text', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
+    });
   } catch (error) {
     console.log("Error: " + error);
   }
 }
+


### PR DESCRIPTION
## Summary
- run Express server on port 4000
- add `/log-text` endpoint that logs posted text
- send taskpane textbox content to the API instead of Outlook message pane

## Testing
- `npm test` (api) *(fails: Error: no test specified)*
- `npm test` (ui) *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_689abf7c461883208ca70eb89ce92368