### PR TITLE
Update manifests to reference local development host

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -14,7 +14,7 @@ const app = express();
 // -------------------- CORS POLICY --------------------- //
 
 const allowedOrigins = [
-    'https://outlook-add-in-ui.onrender.com',
+    // 'https://outlook-add-in-ui.onrender.com',
     'http://localhost:5173',
     'https://localhost:5173',
     'http://localhost:3000',

--- a/ui/manifest.json
+++ b/ui/manifest.json
@@ -36,7 +36,7 @@
         ]
       }
     },
-    "validDomains": ["contoso.com"],
+    "validDomains": ["localhost", "contoso.com"],
     "extensions": [
       {
         "requirements": {
@@ -55,7 +55,7 @@
             "id": "TaskPaneRuntime",
             "type": "general",
             "code": {
-              "page": "https://outlook-add-in-ui.onrender.com/taskpane.html"
+              "page": "https://localhost:3000/taskpane.html"
             },
             "lifetime": "short",
             "actions": [
@@ -71,8 +71,8 @@
             "id": "CommandsRuntime",
             "type": "general",
             "code": {
-              "page": "https://outlook-add-in-ui.onrender.com/commands.html",
-              "script": "https://outlook-add-in-ui.onrender.com/commands.js"
+              "page": "https://localhost:3000/commands.html",
+              "script": "https://localhost:3000/commands.js"
             },
             "lifetime": "short",
             "actions": [
@@ -96,9 +96,9 @@
                     "id": "msgComposeGroup",
                     "label": "Contoso Add-in",
                     "icons": [
-                      { "size": 16, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-16.png" },
-                      { "size": 32, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-32.png" },
-                      { "size": 80, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-80.png" }
+                      { "size": 16, "url": "https://localhost:3000/assets/icon-16.png" },
+                      { "size": 32, "url": "https://localhost:3000/assets/icon-32.png" },
+                      { "size": 80, "url": "https://localhost:3000/assets/icon-80.png" }
                     ],
                     "controls": [
                       {
@@ -106,9 +106,9 @@
                         "type": "button",
                         "label": "Show Task Pane",
                         "icons": [
-                          { "size": 16, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-16.png" },
-                          { "size": 32, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-32.png" },
-                          { "size": 80, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-80.png" }
+                          { "size": 16, "url": "https://localhost:3000/assets/icon-16.png" },
+                          { "size": 32, "url": "https://localhost:3000/assets/icon-32.png" },
+                          { "size": 80, "url": "https://localhost:3000/assets/icon-80.png" }
                         ],
                         "supertip": {
                           "title": "Show Task Pane",
@@ -121,9 +121,9 @@
                         "type": "button",
                         "label": "Perform an action",
                         "icons": [
-                          { "size": 16, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-16.png" },
-                          { "size": 32, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-32.png" },
-                          { "size": 80, "url": "https://outlook-add-in-ui.onrender.com/assets/icon-80.png" }
+                          { "size": 16, "url": "https://localhost:3000/assets/icon-16.png" },
+                          { "size": 32, "url": "https://localhost:3000/assets/icon-32.png" },
+                          { "size": 80, "url": "https://localhost:3000/assets/icon-80.png" }
                         ],
                         "supertip": {
                           "title": "Perform an action",

--- a/ui/manifest.xml
+++ b/ui/manifest.xml
@@ -6,10 +6,14 @@
   <DefaultLocale>en-US</DefaultLocale>
   <DisplayName DefaultValue="ui"/>
   <Description DefaultValue="A template to get started."/>
-  <IconUrl DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-64.png"/>
-  <HighResolutionIconUrl DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-128.png"/>
+  <!-- <IconUrl DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-64.png"/> -->
+  <IconUrl DefaultValue="https://localhost:3000/assets/icon-64.png"/>
+  <!-- <HighResolutionIconUrl DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-128.png"/> -->
+  <HighResolutionIconUrl DefaultValue="https://localhost:3000/assets/icon-128.png"/>
   <SupportUrl DefaultValue="https://www.contoso.com/help"/>
   <AppDomains>
+    <!-- <AppDomain>https://outlook-add-in-ui.onrender.com</AppDomain> -->
+    <AppDomain>https://localhost:3000</AppDomain>
     <AppDomain>https://www.contoso.com</AppDomain>
   </AppDomains>
   <Hosts>
@@ -23,7 +27,8 @@
   <FormSettings>
     <Form xsi:type="ItemRead">
       <DesktopSettings>
-        <SourceLocation DefaultValue="https://outlook-add-in-ui.onrender.com/taskpane.html"/>
+        <!-- <SourceLocation DefaultValue="https://outlook-add-in-ui.onrender.com/taskpane.html"/> -->
+        <SourceLocation DefaultValue="https://localhost:3000/taskpane.html"/>
         <RequestedHeight>250</RequestedHeight>
       </DesktopSettings>
     </Form>
@@ -85,13 +90,18 @@
       </Hosts>
       <Resources>
         <bt:Images>
-          <bt:Image id="Icon.16x16" DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-16.png"/>
-          <bt:Image id="Icon.32x32" DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-32.png"/>
-          <bt:Image id="Icon.80x80" DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-80.png"/>
+          <!-- <bt:Image id="Icon.16x16" DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-16.png"/> -->
+          <bt:Image id="Icon.16x16" DefaultValue="https://localhost:3000/assets/icon-16.png"/>
+          <!-- <bt:Image id="Icon.32x32" DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-32.png"/> -->
+          <bt:Image id="Icon.32x32" DefaultValue="https://localhost:3000/assets/icon-32.png"/>
+          <!-- <bt:Image id="Icon.80x80" DefaultValue="https://outlook-add-in-ui.onrender.com/assets/icon-80.png"/> -->
+          <bt:Image id="Icon.80x80" DefaultValue="https://localhost:3000/assets/icon-80.png"/>
         </bt:Images>
         <bt:Urls>
-          <bt:Url id="Commands.Url" DefaultValue="https://outlook-add-in-ui.onrender.com/commands.html"/>
-          <bt:Url id="Taskpane.Url" DefaultValue="https://outlook-add-in-ui.onrender.com/taskpane.html"/>
+          <!-- <bt:Url id="Commands.Url" DefaultValue="https://outlook-add-in-ui.onrender.com/commands.html"/> -->
+          <bt:Url id="Commands.Url" DefaultValue="https://localhost:3000/commands.html"/>
+          <!-- <bt:Url id="Taskpane.Url" DefaultValue="https://outlook-add-in-ui.onrender.com/taskpane.html"/> -->
+          <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3000/taskpane.html"/>
         </bt:Urls>
         <bt:ShortStrings>
           <bt:String id="GroupLabel" DefaultValue="Contoso Add-in"/>

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -5,7 +5,8 @@ const CopyWebpackPlugin = require("copy-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const webpack = require("webpack");
 
-const urlDev = "https://outlook-add-in-ui.onrender.com"
+// const urlDev = "https://outlook-add-in-ui.onrender.com"
+const urlDev = "https://localhost:3000"
 const urlProd = "https://www.contoso.com/"; // CHANGE THIS TO YOUR PRODUCTION DEPLOYMENT LOCATION
 
 async function getHttpsOptions() {


### PR DESCRIPTION
## Summary
- comment out the previous onrender host entries in the Outlook manifest while keeping the localhost URLs active for sideloading tests
- retain the prior onrender host reference as a comment in the API CORS allow list and document the localhost dev origin in webpack config

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d5a88fc204832094e54dc582e5facc