### PR TITLE
Document metadata pipeline and scrub Outlook body artifacts

### DIFF
--- a/api/controllers/logController.js
+++ b/api/controllers/logController.js
@@ -1,4 +1,5 @@
 import asyncHandler from '../middleware/asyncHandler.js';
+import normalizeEmailPayload from '../utils/normalizeEmailPayload.js';
 
 // ==============================|| Controller - Log ||============================== //
 
@@ -7,11 +8,19 @@ export default {
     // @route      POST /log-text
     // @access     Public
     logText: asyncHandler(async (req, res) => {
-        const { text } = req.body;
-        console.log('----- Email content received from add-in -----');
-        console.log(text);
+        // Normalize the incoming email before any downstream processing so every
+        // subsequent step (retrieval, generation, persistence) receives a clean,
+        // predictable payload shape.
+        const normalizedEmail = normalizeEmailPayload(req.body);
+
+        console.log('----- Email payload received from add-in -----');
+        console.log(JSON.stringify(normalizedEmail, null, 2));
         console.log('----------------------------------------------');
-        res.status(200).json({ message: 'Text logged' });
+
+        res.status(200).json({
+            message: 'Email context normalized',
+            email: normalizedEmail,
+        });
     }),
 };
 

--- a/api/utils/normalizeEmailPayload.js
+++ b/api/utils/normalizeEmailPayload.js
@@ -1,0 +1,100 @@
+// Utility regular expressions for cleaning up Outlook- / Microsoft-generated noise.
+// Zero-width characters such as U+200B (zero-width space) and U+FEFF (BOM) routinely
+// slip into copied email bodies, so we strip them before handing content off to
+// downstream services.
+const INVISIBLE_MICROSOFT_CHARS = /[\u200B\u200C\u200D\u200E\u200F\u202A-\u202E\u2060\uFEFF]/g;
+// Outlook often relies on non-breaking spaces for layout; replacing them with normal
+// spaces makes it easier for LLM prompts to treat them as word separators.
+const NBSP_REGEX = /\u00A0/g;
+// Collapse consecutive spaces and tabs so the prompt is easier to read. We leave two
+// newlines intact because they communicate paragraph breaks.
+const MULTI_SPACE_REGEX = /[ \t]{2,}/g;
+
+// Generic string sanitizer that trims leading/trailing whitespace and normalizes
+// empty strings to null so callers can easily test the presence of a value.
+const sanitizeString = (value) => {
+    if (typeof value !== 'string') {
+        return null;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed.length > 0 ? trimmed : null;
+};
+
+// Helper specifically for the sender object: we sanitize both the display name and
+// the email address, lower-casing the latter so it can be matched reliably in search.
+const sanitizeSender = (sender) => {
+    if (!sender || typeof sender !== 'object') {
+        return null;
+    }
+
+    const displayName = sanitizeString(sender.displayName);
+    const emailAddressRaw = sanitizeString(sender.emailAddress);
+    const emailAddress = emailAddressRaw ? emailAddressRaw.toLowerCase() : null;
+
+    if (!displayName && !emailAddress) {
+        return null;
+    }
+
+    return {
+        displayName,
+        emailAddress,
+    };
+};
+
+// Microsoft properties frequently contain control characters or exotic whitespace.
+// This helper strips those artifacts while preserving deliberate formatting such as
+// paragraph breaks so we can hand OpenAI a clean, human-readable prompt.
+const normalizeBodyText = (text) => {
+    const sanitized = sanitizeString(text) ?? '';
+
+    if (!sanitized) {
+        return '';
+    }
+
+    return sanitized
+        // First remove invisible control characters that contribute noise.
+        .replace(INVISIBLE_MICROSOFT_CHARS, '')
+        // Then replace non-breaking spaces with standard spaces.
+        .replace(NBSP_REGEX, ' ')
+        // Normalise Windows line endings to plain \n so downstream diffs are stable.
+        .replace(/\r\n?/g, '\n')
+        // Collapse sequences of spaces/tabs while leaving single spaces untouched.
+        .replace(MULTI_SPACE_REGEX, ' ')
+        // Finally, trim again in case the replacements introduced leading/trailing spaces.
+        .trim();
+};
+
+const normalizeEmailPayload = (payload = {}) => {
+    const { text, metadata } = payload;
+
+    // Clean up the body so that downstream retrieval / generation services see a
+    // consistent shape regardless of the odd characters Outlook occasionally emits.
+    const normalizedBody = normalizeBodyText(text);
+
+    // Pre-initialize the metadata structure so consumers can rely on the shape even
+    // when the Outlook item does not expose particular fields (e.g., conversationId
+    // for drafts).
+    const normalizedMetadata = {
+        subject: null,
+        sender: null,
+        conversationId: null,
+        internetMessageId: null,
+    };
+
+    if (metadata && typeof metadata === 'object') {
+        normalizedMetadata.subject = sanitizeString(metadata.subject);
+        normalizedMetadata.sender = sanitizeSender(metadata.sender);
+        normalizedMetadata.conversationId = sanitizeString(metadata.conversationId);
+        normalizedMetadata.internetMessageId = sanitizeString(metadata.internetMessageId);
+    }
+
+    return {
+        body: normalizedBody,
+        metadata: normalizedMetadata,
+    };
+};
+
+export default normalizeEmailPayload;
+

--- a/ui/src/taskpane/taskpane.ts
+++ b/ui/src/taskpane/taskpane.ts
@@ -1,5 +1,68 @@
 /* global console, Office, fetch */
 
+type BasicEmailMetadata = {
+  subject?: string | null;
+  sender?: {
+    displayName?: string | null;
+    emailAddress?: string | null;
+  } | null;
+  conversationId?: string | null;
+  internetMessageId?: string | null;
+};
+
+// Mirrors the server-side sanitizer so that we only send meaningful values across
+// the wire. Returning null instead of "" makes it obvious when a field is absent.
+const sanitizeString = (value: unknown): string | null => {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+};
+
+// Collect a minimal metadata envelope (subject, sender, threading identifiers) that
+// is useful both for retrieval ranking and for threading responses later on.
+const collectEmailMetadata = (): BasicEmailMetadata => {
+  const mailbox = Office.context.mailbox;
+  const currentItem = mailbox?.item as any;
+
+  if (!currentItem) {
+    // Returning an empty object allows the server to safely merge defaults without
+    // special-casing undefined metadata.
+    return {};
+  }
+
+  const subject = sanitizeString(currentItem.subject);
+  const conversationId = sanitizeString(currentItem.conversationId);
+  const internetMessageId = sanitizeString(currentItem.internetMessageId);
+
+  // Depending on the Outlook surface, sender info may live on either `from` or `sender`.
+  const potentialSender = currentItem.from ?? currentItem.sender ?? null;
+  let sender: BasicEmailMetadata["sender"] = null;
+
+  if (potentialSender && typeof potentialSender === "object") {
+    const displayName = sanitizeString((potentialSender as any).displayName);
+    const emailAddressRaw = sanitizeString((potentialSender as any).emailAddress);
+    const emailAddress = emailAddressRaw ? emailAddressRaw.toLowerCase() : null;
+
+    if (displayName || emailAddress) {
+      // Only include the sender object when we have at least one useful attribute.
+      sender = {
+        displayName,
+        emailAddress,
+      };
+    }
+  }
+
+  return {
+    subject,
+    sender,
+    conversationId,
+    internetMessageId,
+  };
+};
+
 export async function sendText(): Promise<void> {
   // The Outlook item that is currently being viewed is available via Office.js.
   // We wrap the callback-based body.getAsync API in a Promise so it plays nicely with async/await.
@@ -32,12 +95,13 @@ export async function sendText(): Promise<void> {
   try {
     // Retrieve the body of the current email as plain text.
     const bodyText = await getBodyText();
+    const metadata = collectEmailMetadata();
 
     // Post the email content to the local development server for logging.
     await fetch(`http://localhost:4000/log-text`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: bodyText }),
+      body: JSON.stringify({ text: bodyText, metadata }),
     });
     // await fetch(`https://outlook-add-in-kdr8.onrender.com/log-text`, {
     //   method: "POST",


### PR DESCRIPTION
## Summary
- annotate the log-text controller and task pane helpers so the metadata pipeline is easier to follow
- strip common Outlook zero-width and non-breaking characters before handing the email body to downstream services
- align the client and server sanitizers for sender and threading metadata

## Testing
- `cd ui && npm run lint` *(fails: office-addin-lint not found in container image)*

------
https://chatgpt.com/codex/tasks/task_e_68d5c2995c508320b6e3be72682e5551