### PR TITLE
Open task pane directly from ribbon button

### DIFF
--- a/ui/manifest.xml
+++ b/ui/manifest.xml
@@ -67,21 +67,6 @@
                       <SourceLocation resid="Taskpane.Url"/>
                     </Action>
                   </Control>
-                  <Control xsi:type="Button" id="ActionButton">
-                    <Label resid="ActionButton.Label"/>
-                    <Supertip>
-                      <Title resid="ActionButton.Label"/>
-                      <Description resid="ActionButton.Tooltip"/>
-                    </Supertip>
-                    <Icon>
-                      <bt:Image size="16" resid="Icon.16x16"/>
-                      <bt:Image size="32" resid="Icon.32x32"/>
-                      <bt:Image size="80" resid="Icon.80x80"/>
-                    </Icon>
-                    <Action xsi:type="ExecuteFunction">
-                      <FunctionName>action</FunctionName>
-                    </Action>
-                  </Control>
                 </Group>
               </OfficeTab>
             </ExtensionPoint>
@@ -106,11 +91,9 @@
         <bt:ShortStrings>
           <bt:String id="GroupLabel" DefaultValue="Contoso Add-in"/>
           <bt:String id="TaskpaneButton.Label" DefaultValue="Show Task Pane"/>
-          <bt:String id="ActionButton.Label" DefaultValue="Perform an action"/>
         </bt:ShortStrings>
         <bt:LongStrings>
           <bt:String id="TaskpaneButton.Tooltip" DefaultValue="Opens a pane that enables users to insert text."/>
-          <bt:String id="ActionButton.Tooltip" DefaultValue="Perform an action when clicked."/>
         </bt:LongStrings>
       </Resources>
     </VersionOverrides>

--- a/ui/src/commands/commands.ts
+++ b/ui/src/commands/commands.ts
@@ -6,30 +6,20 @@
 /* global Office */
 
 Office.onReady(() => {
-  // If needed, Office.js is ready to be called.
+  if (Office && Office.addin && typeof Office.addin.showAsTaskpane === "function") {
+    Office.addin
+      .showAsTaskpane()
+      .then(() => {
+        if (
+          Office.context &&
+          Office.context.ui &&
+          typeof Office.context.ui.closeContainer === "function"
+        ) {
+          Office.context.ui.closeContainer();
+        }
+      })
+      .catch(() => {
+        // no-op: if the host does not support showAsTaskpane we leave the default behavior
+      });
+  }
 });
-
-/**
- * Shows a notification when the add-in command is executed.
- * @param event
- */
-function action(event: Office.AddinCommands.Event) {
-  const message: Office.NotificationMessageDetails = {
-    type: Office.MailboxEnums.ItemNotificationMessageType.InformationalMessage,
-    message: "Performed action.",
-    icon: "Icon.80x80",
-    persistent: true,
-  };
-
-  // Show a notification message.
-  Office.context.mailbox.item?.notificationMessages.replaceAsync(
-    "ActionPerformanceNotification",
-    message
-  );
-
-  // Be sure to indicate when the add-in command function is complete.
-  event.completed();
-}
-
-// Register the function with Office.
-Office.actions.associate("action", action);

--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -1,9 +1,7 @@
 import * as React from "react";
 import Header from "./Header";
-import HeroList, { HeroListItem } from "./HeroList";
 import TextInsertion from "./TextInsertion";
 import { makeStyles } from "@fluentui/react-components";
-import { Ribbon24Regular, LockOpen24Regular, DesignIdeas24Regular } from "@fluentui/react-icons";
 import { sendText } from "../taskpane";
 
 interface AppProps {
@@ -18,28 +16,10 @@ const useStyles = makeStyles({
 
 const App: React.FC<AppProps> = (props: AppProps) => {
   const styles = useStyles();
-  // The list items are static and won't change at runtime,
-  // so this should be an ordinary const, not a part of state.
-  const listItems: HeroListItem[] = [
-    {
-      icon: <Ribbon24Regular />,
-      primaryText: "Achieve more with Office integration",
-    },
-    {
-      icon: <LockOpen24Regular />,
-      primaryText: "Unlock features and functionality",
-    },
-    {
-      icon: <DesignIdeas24Regular />,
-      primaryText: "Create and visualize like a pro",
-    },
-  ];
-
   return (
     <div className={styles.root}>
       <Header logo="assets/logo-filled.png" title={props.title} message="Welcome" />
-      <HeroList message="Discover what this add-in can do for you today!" items={listItems} />
-        <TextInsertion sendText={sendText} />
+      <TextInsertion sendText={sendText} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- remove the extra command button from the Outlook add-in manifest so the task pane opens immediately
- streamline the task pane welcome view by removing the unused hero list text
- trigger the Office.addin.showAsTaskpane flow from the command surface so clicking the add-in opens the pane without an intermediate dropdown

## Testing
- npm run lint *(fails: existing prettier/no-undef violations in src/taskpane/helpers/emailAddress.ts and related files)*

------
https://chatgpt.com/codex/tasks/task_e_68d60fd201ec8320b245d5cc2b05750b