### PR TITLE
Restore logging when sending email content

### DIFF
--- a/api/controllers/logController.js
+++ b/api/controllers/logController.js
@@ -36,6 +36,22 @@ export default {
     // @access     Public
     logText: asyncHandler(async (req, res) => {
         const ingestResult = await ingestEmailSubmission(req.body);
+
+        const {
+            body: normalizedBody,
+            metadata: { subject, sender },
+        } = ingestResult.normalizedEmail;
+
+        const senderLabel = sender?.displayName || sender?.emailAddress || 'Unknown sender';
+        const preview = normalizedBody.replace(/\s+/g, ' ').trim().slice(0, 200);
+
+        console.info('📬  Email submission received from Outlook add-in');
+        console.info(`     From   : ${senderLabel}`);
+        console.info(`     Subject: ${subject || '(no subject)'}`);
+        console.info(
+            `     Preview: ${preview}${normalizedBody.length > 200 ? '…' : ''}`
+        );
+
         const retrievalPlan = await retrieveContextForEmail(ingestResult.normalizedEmail);
         const generationPlan = await generateCandidateResponses(retrievalPlan);
         const verificationPlan = await verifyCandidateResponses(generationPlan);

--- a/ui/src/taskpane/taskpane.ts
+++ b/ui/src/taskpane/taskpane.ts
@@ -33,8 +33,12 @@ export async function sendText(): Promise<void> {
     });
 
   try {
+    console.info("[Taskpane] Send email content button pressed. Retrieving email body...");
     // Retrieve the body of the current email as plain text so it can be sent to the backend.
     const bodyText = await getBodyText();
+    console.info(
+      `[Taskpane] Email body retrieved (${bodyText.length} characters). Preparing to post to the logging service...`
+    );
     // Build a metadata payload (subject, sender, conversation info) to accompany the body content.
     const metadata = await buildEmailMetadata();
 
@@ -46,6 +50,7 @@ export async function sendText(): Promise<void> {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text: bodyText, metadata }),
     });
+    console.info("[Taskpane] Email content successfully posted to the logging service.");
     // await fetch(`https://outlook-add-in-kdr8.onrender.com/log-text`, {
     //   method: "POST",
     //   headers: { "Content-Type": "application/json" },


### PR DESCRIPTION
## Summary
- add console instrumentation to the taskpane flow so pressing the send button logs each step
- log normalized email metadata and a content preview on the server when submissions arrive

## Testing
- npm run lint *(fails: existing prettier/no-undef issues in ui/src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68d63a566e8c8320afe30e8fd4bfdaaf