### PR TITLE
Add richer telemetry logging and retrieval hints

### DIFF
--- a/api/controllers/logController.js
+++ b/api/controllers/logController.js
@@ -52,8 +52,47 @@ export default {
             `     Preview: ${preview}${normalizedBody.length > 200 ? '…' : ''}`
         );
 
+        if (ingestResult?.ingestTelemetry) {
+            console.info('🧾  Ingest telemetry snapshot:');
+            console.dir(ingestResult.ingestTelemetry, { depth: null });
+        }
+
+        if (Array.isArray(ingestResult?.vectorStoreIndex)) {
+            console.info(
+                `📚  Indexed vector store handles: ${ingestResult.vectorStoreIndex.length}`
+            );
+        }
+
         const retrievalPlan = await retrieveContextForEmail(ingestResult.normalizedEmail);
+
+        console.info('🧠  Retrieval plan hints:');
+        console.dir(
+            {
+                vectorStoreHandles: retrievalPlan?.vectorStoreHandles || [],
+                searchHints: retrievalPlan?.searchHints || {},
+            },
+            { depth: null }
+        );
+
         const generationPlan = await generateCandidateResponses(retrievalPlan);
+
+        if (generationPlan?.questionPlan) {
+            const { match, assistantPlan } = generationPlan.questionPlan;
+            console.info('🤖  Question classification result:');
+            console.dir(
+                {
+                    isApprovedQuestion: match?.isApprovedQuestion || false,
+                    questionId: match?.questionId || null,
+                    confidence: match?.confidence || null,
+                    reasoning: match?.reasoning || null,
+                    answerSummary: assistantPlan?.answerSummary || null,
+                },
+                { depth: null }
+            );
+        } else {
+            console.info('🤖  Question classification result: unavailable');
+        }
+
         const verificationPlan = await verifyCandidateResponses(generationPlan);
 
         const questionPlan = verificationPlan?.questionPlan || null;


### PR DESCRIPTION
## Summary
- log ingest telemetry, retrieval hints, and question classification details inside the pipeline orchestrator for easier debugging
- derive subject keywords and a normalized sender domain so retrieval hints are actionable when vector search is introduced

## Testing
- not run (not available)

------
https://chatgpt.com/codex/tasks/task_e_68db69b2d1dc8320af9c872796aa5569