### PR TITLE
Refine prompt roles for question response builder

### DIFF
--- a/api/utils/promptWrappers.js
+++ b/api/utils/promptWrappers.js
@@ -180,16 +180,13 @@ export const buildQuestionResponsePrompt = (normalizedEmail) => {
         'Never guess or hallucinate. If information cannot be verified, surface the uncertainty, explain any gaps plainly, and recommend a human follow-up instead of inventing policy.',
     ].join(' ');
 
-    const userInstruction = [
-        'Resident email (plain text):',
-        '---',
-        `${headerBlock}${normalizedEmail?.body || '(no body provided)'}`,
-        '---',
+    const developerInstruction = [
+        'Follow these directives when drafting response plans for PEKA residents.',
         '',
         'Approved condo management questions you may answer:',
         approvedQuestionText,
         '',
-        'Tasks:',
+        'Directives:',
         '1. Determine if the resident is effectively asking one of the approved questions (allowing paraphrasing).',
         '2. If matched, list every approved question that applies in match.matchedQuestions (the first entry should be the primary focus) and mirror the leading entry in match.questionId and match.questionTitle.',
         '3. If matched, open and read the first linked PEKA resource (and any other relevant condo resources) before answering. Capture the exact language that resolves the question and plan to echo it back to the resident.',
@@ -197,12 +194,19 @@ export const buildQuestionResponsePrompt = (normalizedEmail) => {
         '5. If not matched, clearly explain that you are stepping outside PEKA internal resources, use the web_search tool to gather guidance from reputable public sources, and keep searching until you find trustworthy material or exhaust reasonable options.',
         '6. When external research yields usable guidance, base your answer entirely on that material and describe any limitations or uncertainties you observed.',
         '7. If no credible information can be found, explicitly state that outcome, highlight the open questions, and recommend a human follow-up instead of speculating.',
-        '8. Draft emailReply as a complete, empathetic email response addressed to the resident. Open with a friendly greeting, reference the verified language you just reviewed, quote or paraphrase the key instructions, include the exact URL, and close with a supportive sign-off that invites further questions. Please refrain from including final signatures, in general, or including PEKA contact information as a signature',
+        '8. Draft emailReply as a complete, empathetic email response addressed to the resident. Open with a friendly greeting, reference the verified language you just reviewed, quote or paraphrase the key instructions, include the exact URL, and close with a supportive sign-off that invites further questions. Please refrain from including final signatures, in general, or including PEKA contact information as a signature.',
         '9. When relying on external research because no catalog question applied, explicitly note in emailReply that the guidance comes from public sources and mention any limitations or uncertainty.',
         '10. Produce 2-8 actionable internal follow-up steps with short titles and supporting details that reflect the certainty level.',
         '11. Only when applicable, suggest 1-3 resident-facing follow-up messages that maintain a helpful tone and communicate any uncertainty honestly.',
         '12. Populate sourceCitations with every supporting link you used; do not impose an artificial cap. Each citation must contain the exact URL visited, a short title, and the excerpt or policy detail that supports your summary. If no reliable source exists, include a single placeholder citation that clearly states no trustworthy reference was found and recommend human follow-up.',
         '13. Always fill the provided JSON schema and do not include extra commentary or markdown.',
+    ].join('\n');
+
+    const userInstruction = [
+        'Resident email (plain text):',
+        '---',
+        `${headerBlock}${normalizedEmail?.body || '(no body provided)'}`,
+        '---',
     ].join('\n');
 
     return [
@@ -212,6 +216,15 @@ export const buildQuestionResponsePrompt = (normalizedEmail) => {
                 {
                     type: 'input_text',
                     text: baseSystemInstruction,
+                },
+            ],
+        },
+        {
+            role: 'developer',
+            content: [
+                {
+                    type: 'input_text',
+                    text: developerInstruction,
                 },
             ],
         },


### PR DESCRIPTION
## Summary
- move condo operations directives into a developer-role instruction for the Responses API prompt
- keep the resident email payload as the sole content of the user-role message to align with latest guidance

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de12c7ebc08320b98a7ab8ff0c7d8b