### PR TITLE
Add optional prompt forwarding to response generation

### DIFF
--- a/api/utils/normalizeEmailPayload.js
+++ b/api/utils/normalizeEmailPayload.js
@@ -58,6 +58,7 @@ const normalizeBodyText = (text) => {
 
 const normalizeEmailPayload = (payload = {}) => {
     const { text, metadata } = payload;
+    const optionalPrompt = sanitizeString(payload?.optionalPrompt);
 
     // Clean up the body so that downstream retrieval / generation services see a
     // consistent shape regardless of the odd characters Outlook occasionally emits.
@@ -83,6 +84,7 @@ const normalizeEmailPayload = (payload = {}) => {
     return {
         body: normalizedBody,
         metadata: normalizedMetadata,
+        optionalPrompt,
     };
 };
 

--- a/api/utils/promptWrappers.js
+++ b/api/utils/promptWrappers.js
@@ -119,6 +119,10 @@ export const buildQuestionResponsePrompt = (normalizedEmail) => {
     const subject = normalizedEmail?.metadata?.subject;
     const senderName = normalizedEmail?.metadata?.sender?.displayName;
     const senderEmail = normalizedEmail?.metadata?.sender?.emailAddress;
+    const optionalPrompt =
+        typeof normalizedEmail?.optionalPrompt === 'string'
+            ? normalizedEmail.optionalPrompt
+            : null;
 
     // ============================|| Email Header Stitching ||============================ //
     // The model performs better when it sees the same headers a human agent would use to
@@ -210,7 +214,7 @@ export const buildQuestionResponsePrompt = (normalizedEmail) => {
         '13. Always fill the provided JSON schema and do not include extra commentary or markdown.',
     ].join('\n');
 
-    return [
+    const messages = [
         {
             role: 'system',
             content: [
@@ -229,16 +233,34 @@ export const buildQuestionResponsePrompt = (normalizedEmail) => {
                 },
             ],
         },
-        {
-            role: 'user',
+    ];
+
+    if (optionalPrompt) {
+        messages.push({
+            role: 'developer',
             content: [
                 {
                     type: 'input_text',
-                    text: userInstruction,
+                    text: [
+                        'Additional operator instructions for this request:',
+                        optionalPrompt,
+                    ].join('\n\n'),
                 },
             ],
-        }
-    ];
+        });
+    }
+
+    messages.push({
+        role: 'user',
+        content: [
+            {
+                type: 'input_text',
+                text: userInstruction,
+            },
+        ],
+    });
+
+    return messages;
 };
 
 export default {


### PR DESCRIPTION
## Summary
- capture an optionalPrompt value during ingestion so downstream stages can access it
- inject any provided optional instructions into the Responses API developer messages

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68df6f6c53048320bcfcd393c3e53607