### PR TITLE
Display pipeline response in task pane

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,9 +1,10 @@
 import * as React from "react";
 import { useState } from "react";
 import { Button, Field, Textarea, tokens, makeStyles } from "@fluentui/react-components";
+import { PipelineResponse } from "../taskpane";
 
 interface TextInsertionProps {
-  sendText: () => Promise<void>;
+  sendText: () => Promise<PipelineResponse>;
 }
 
 const useStyles = makeStyles({
@@ -28,17 +29,21 @@ const useStyles = makeStyles({
 
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
   const [statusMessage, setStatusMessage] = useState<string>("");
+  const [pipelineResponse, setPipelineResponse] = useState<string>("");
   const [isSending, setIsSending] = useState<boolean>(false);
 
   const handleTextSend = async () => {
     try {
       setIsSending(true);
       setStatusMessage("Sending the current email content...");
-      await props.sendText();
+      setPipelineResponse("");
+      const response = await props.sendText();
       setStatusMessage("Email content sent to the server.");
+      setPipelineResponse(JSON.stringify(response, null, 2));
     } catch (error) {
       console.error(error);
       setStatusMessage("We couldn't send the email content. Please try again.");
+      setPipelineResponse("");
     } finally {
       setIsSending(false);
     }
@@ -53,6 +58,9 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
       </Field>
       <Field className={styles.textAreaField} label="Status" size="large">
         <Textarea value={statusMessage} readOnly resize="vertical" />
+      </Field>
+      <Field className={styles.textAreaField} label="Pipeline response" size="large">
+        <Textarea value={pipelineResponse} readOnly resize="vertical" />
       </Field>
       <Button appearance="primary" disabled={isSending} size="large" onClick={handleTextSend}>
         {isSending ? "Sending..." : "Send email content"}


### PR DESCRIPTION
## Summary
- return the pipeline response payload from the task pane sendText helper
- show the serialized pipeline response in the task pane alongside status messaging

## Testing
- npm run lint *(fails: existing prettier/no-undef issues in ui/src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68df7ad44b48832098de89aec57f7f97