### PR TITLE
Improve taskpane layout responsiveness

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -13,6 +13,10 @@ interface AppProps {
 const useStyles = makeStyles({
     root: {
         minHeight: "100vh",
+        width: "100%",
+        maxWidth: "100%",
+        display: "flex",
+        flexDirection: "column",
     },
 });
 

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { Button, Field, Textarea, tokens, makeStyles } from "@fluentui/react-components";
 import { PipelineResponse } from "../taskpane";
 
@@ -8,48 +8,62 @@ interface TextInsertionProps {
 }
 
 const useStyles = makeStyles({
-  instructions: {
-    fontWeight: tokens.fontWeightSemibold,
-    marginTop: "20px",
-    marginBottom: "10px",
-  },
   textPromptAndInsertion: {
     display: "flex",
     flexDirection: "column",
-    alignItems: "center",
+    alignItems: "stretch",
+    gap: "16px",
+    padding: "24px",
+    width: "100%",
+    boxSizing: "border-box",
+  },
+  instructions: {
+    fontWeight: tokens.fontWeightSemibold,
   },
   textAreaField: {
-    marginLeft: "20px",
-    marginTop: "30px",
-    marginBottom: "20px",
-    marginRight: "20px",
-    maxWidth: "50%",
+    width: "100%",
+  },
+  textArea: {
+    width: "100%",
+  },
+  linksList: {
+    margin: 0,
+    paddingLeft: "20px",
+  },
+  linksSection: {
+    display: "flex",
+    flexDirection: "column",
+    gap: "4px",
   },
 });
 
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
   const [statusMessage, setStatusMessage] = useState<string>("");
-  const [pipelineResponse, setPipelineResponse] = useState<string>("");
+  const [pipelineResponse, setPipelineResponse] = useState<PipelineResponse | null>(null);
   const [isSending, setIsSending] = useState<boolean>(false);
 
   const handleTextSend = async () => {
     try {
       setIsSending(true);
       setStatusMessage("Sending the current email content...");
-      setPipelineResponse("");
+      setPipelineResponse(null);
       const response = await props.sendText();
       setStatusMessage("Email content sent to the server.");
-      setPipelineResponse(JSON.stringify(response, null, 2));
+      setPipelineResponse(response);
     } catch (error) {
       console.error(error);
       setStatusMessage("We couldn't send the email content. Please try again.");
-      setPipelineResponse("");
+      setPipelineResponse(null);
     } finally {
       setIsSending(false);
     }
   };
 
   const styles = useStyles();
+  const pipelineResponseAsJson = useMemo(
+    () => (pipelineResponse ? JSON.stringify(pipelineResponse, null, 2) : ""),
+    [pipelineResponse]
+  );
 
   return (
     <div className={styles.textPromptAndInsertion}>
@@ -57,11 +71,33 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
         Press the button to send the body of the email you're viewing to the server.
       </Field>
       <Field className={styles.textAreaField} label="Status" size="large">
-        <Textarea value={statusMessage} readOnly resize="vertical" />
+        <Textarea className={styles.textArea} value={statusMessage} readOnly resize="vertical" />
       </Field>
       <Field className={styles.textAreaField} label="Pipeline response" size="large">
-        <Textarea value={pipelineResponse} readOnly resize="vertical" />
+        <Textarea
+          className={styles.textArea}
+          value={pipelineResponseAsJson}
+          readOnly
+          resize="vertical"
+        />
       </Field>
+      {pipelineResponse?.assistantResponse?.sourceCitations?.length ? (
+        <div className={styles.linksSection}>
+          <Field className={styles.textAreaField} label="Links provided">
+            <ul className={styles.linksList}>
+              {pipelineResponse.assistantResponse.sourceCitations.map((citation, index) =>
+                citation?.url ? (
+                  <li key={`${citation.url}-${index}`}>
+                    <a href={citation.url} target="_blank" rel="noreferrer">
+                      {citation.title || citation.url}
+                    </a>
+                  </li>
+                ) : null
+              )}
+            </ul>
+          </Field>
+        </div>
+      ) : null}
       <Button appearance="primary" disabled={isSending} size="large" onClick={handleTextSend}>
         {isSending ? "Sending..." : "Send email content"}
       </Button>


### PR DESCRIPTION
## Summary
- stretch the taskpane layout so controls use the full available width
- widen status and pipeline response text areas for better readability
- surface returned citation links as a clickable list beneath the response output

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df7f952c10832095249bba42bb2d6e