### PR TITLE
Add optional instructions field to taskpane

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,10 +1,17 @@
 import * as React from "react";
 import { useMemo, useState } from "react";
-import { Button, Field, Textarea, tokens, makeStyles } from "@fluentui/react-components";
+import {
+  Button,
+  Field,
+  Textarea,
+  TextareaOnChangeData,
+  tokens,
+  makeStyles,
+} from "@fluentui/react-components";
 import { PipelineResponse } from "../taskpane";
 
 interface TextInsertionProps {
-  sendText: () => Promise<PipelineResponse>;
+  sendText: (optionalPrompt?: string) => Promise<PipelineResponse>;
 }
 
 const useStyles = makeStyles({
@@ -20,6 +27,13 @@ const useStyles = makeStyles({
   },
   instructions: {
     fontWeight: tokens.fontWeightSemibold,
+  },
+  optionalPromptField: {
+    width: "100%",
+  },
+  optionalPromptTextArea: {
+    width: "100%",
+    minHeight: "140px",
   },
   statusField: {
     width: "100%",
@@ -52,19 +66,26 @@ const useStyles = makeStyles({
   linksField: {
     width: "100%",
   },
+  actionsRow: {
+    display: "flex",
+    flexWrap: "wrap",
+    gap: "12px",
+  },
 });
 
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
   const [statusMessage, setStatusMessage] = useState<string>("");
   const [pipelineResponse, setPipelineResponse] = useState<PipelineResponse | null>(null);
   const [isSending, setIsSending] = useState<boolean>(false);
+  const [isOptionalPromptVisible, setIsOptionalPromptVisible] = useState<boolean>(false);
+  const [optionalPrompt, setOptionalPrompt] = useState<string>("");
 
   const handleTextSend = async () => {
     try {
       setIsSending(true);
       setStatusMessage("Sending the current email content...");
       setPipelineResponse(null);
-      const response = await props.sendText();
+      const response = await props.sendText(optionalPrompt.trim() || undefined);
       setStatusMessage("Email content sent to the server.");
       setPipelineResponse(response);
     } catch (error) {
@@ -87,6 +108,34 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
       <Field className={styles.instructions}>
         Press the button to send the body of the email you're viewing to the server.
       </Field>
+      <div className={styles.actionsRow}>
+        <Button
+          appearance="secondary"
+          disabled={isSending}
+          onClick={() => setIsOptionalPromptVisible((previous) => !previous)}
+        >
+          {isOptionalPromptVisible ? "Hide instructions" : "Add instructions"}
+        </Button>
+      </div>
+      {isOptionalPromptVisible ? (
+        <Field
+          className={styles.optionalPromptField}
+          label="Additional instructions"
+          size="large"
+          hint="Provide extra guidance for the assistant."
+        >
+          <Textarea
+            className={styles.optionalPromptTextArea}
+            value={optionalPrompt}
+            onChange={(
+              _event: React.ChangeEvent<HTMLTextAreaElement>,
+              data: TextareaOnChangeData
+            ) => setOptionalPrompt(data.value)}
+            placeholder="Add extra details or tone preferences for the generated response."
+            resize="vertical"
+          />
+        </Field>
+      ) : null}
       <Field className={styles.statusField} label="Status" size="large">
         <Textarea className={styles.statusTextArea} value={statusMessage} readOnly />
       </Field>

--- a/ui/src/taskpane/taskpane.ts
+++ b/ui/src/taskpane/taskpane.ts
@@ -14,7 +14,7 @@ export interface PipelineResponse {
   };
 }
 
-export async function sendText(): Promise<PipelineResponse> {
+export async function sendText(optionalPrompt?: string): Promise<PipelineResponse> {
   // The Outlook item that is currently being viewed is available via Office.js.
   // We wrap the callback-based body.getAsync API in a Promise so it plays nicely with async/await.
   // Using a helper here keeps the flow in the try/catch block easy to read.
@@ -60,7 +60,11 @@ export async function sendText(): Promise<PipelineResponse> {
     const response = await fetch(`http://localhost:4000/log-text`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ text: bodyText, metadata }),
+      body: JSON.stringify({
+        text: bodyText,
+        metadata,
+        optionalPrompt: optionalPrompt?.trim() || undefined,
+      }),
     });
     if (!response.ok) {
       const errorText = await response.text();


### PR DESCRIPTION
## Summary
- add a toggleable "Add instructions" button that reveals an additional prompt text area in the taskpane
- pass the optional instructions back through the existing pipeline payload so the server receives the extra guidance

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df8a77c3f48320be48c75fcb9ab5f2