### PR TITLE
Add shared runtime persistence for Outlook task pane

### DIFF
--- a/ui/manifest.json
+++ b/ui/manifest.json
@@ -42,40 +42,30 @@
         "requirements": {
           "scopes": ["mail"],
           "capabilities": [
-            { "name": "Mailbox", "minVersion": "1.3" }
+            { "name": "Mailbox", "minVersion": "1.10" }
           ]
         },
         "runtimes": [
           {
             "requirements": {
               "capabilities": [
-                { "name": "Mailbox", "minVersion": "1.3" }
+                { "name": "Mailbox", "minVersion": "1.10" },
+                { "name": "SharedRuntime", "minVersion": "1.1" }
               ]
             },
-            "id": "TaskPaneRuntime",
+            "id": "SharedRuntime",
             "type": "general",
             "code": {
               "page": "https://localhost:3000/taskpane.html"
             },
-            "lifetime": "short",
+            "lifetime": "long",
             "actions": [
               {
-                "id": "TaskPaneRuntimeShow",
-                "type":"openPage",
+                "id": "ShowTaskPane",
+                "type": "openPage",
                 "pinnable": false,
                 "view": "dashboard"
-              }
-            ]
-          },
-          {
-            "id": "CommandsRuntime",
-            "type": "general",
-            "code": {
-              "page": "https://localhost:3000/commands.html",
-              "script": "https://localhost:3000/commands.js"
-            },
-            "lifetime": "short",
-            "actions": [
+              },
               {
                 "id": "action",
                 "type": "executeFunction"
@@ -114,7 +104,7 @@
                           "title": "Show Task Pane",
                           "description": "Opens a task pane."
                         },
-                        "actionId": "TaskPaneRuntimeShow"
+                        "actionId": "ShowTaskPane"
                       },
                       {
                         "id": "ActionButton",

--- a/ui/manifest.xml
+++ b/ui/manifest.xml
@@ -47,7 +47,7 @@
       <Hosts>
         <Host xsi:type="MailHost">
           <DesktopFormFactor>
-            <FunctionFile resid="Commands.Url"/>
+            <FunctionFile resid="Taskpane.Url"/>
             <ExtensionPoint xsi:type="MessageComposeCommandSurface">
               <OfficeTab id="TabDefault">
                 <Group id="msgComposeGroup">
@@ -98,8 +98,6 @@
           <bt:Image id="Icon.80x80" DefaultValue="https://localhost:3000/assets/icon-80.png"/>
         </bt:Images>
         <bt:Urls>
-          <!-- <bt:Url id="Commands.Url" DefaultValue="https://outlook-add-in-ui.onrender.com/commands.html"/> -->
-          <bt:Url id="Commands.Url" DefaultValue="https://localhost:3000/commands.html"/>
           <!-- <bt:Url id="Taskpane.Url" DefaultValue="https://outlook-add-in-ui.onrender.com/taskpane.html"/> -->
           <bt:Url id="Taskpane.Url" DefaultValue="https://localhost:3000/taskpane.html"/>
         </bt:Urls>

--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -1,35 +1,204 @@
+/* global Office, console */
+
 import * as React from "react";
+import { makeStyles } from "@fluentui/react-components";
 import Header from "./Header";
-import HeroList, {HeroListItem} from "./HeroList";
 import TextInsertion from "./TextInsertion";
-import {makeStyles} from "@fluentui/react-components";
-import {Ribbon24Regular, LockOpen24Regular, DesignIdeas24Regular} from "@fluentui/react-icons";
-import {sendText} from "../taskpane";
+import { sendText } from "../taskpane";
+import {
+  createEmptyState,
+  loadPersistedState,
+  PersistedTaskPaneState,
+  savePersistedState,
+} from "../helpers/persistence";
+import { resolveStorageKeyForCurrentItem } from "../helpers/mailboxItem";
+import { registerTaskpaneVisibilityHandler } from "../helpers/runtime";
 
 interface AppProps {
-    title: string;
+  title: string;
 }
 
 const useStyles = makeStyles({
-    root: {
-        minHeight: "100vh",
-        width: "100%",
-        maxWidth: "100%",
-        display: "flex",
-        flexDirection: "column",
-    },
+  root: {
+    minHeight: "100vh",
+    width: "100%",
+    maxWidth: "100%",
+    display: "flex",
+    flexDirection: "column",
+  },
 });
 
-const App: React.FC<AppProps> = (props: AppProps) => {
-    const styles = useStyles();
+const App: React.FC<AppProps> = ({ title }) => {
+  const styles = useStyles();
+  const [viewState, setViewState] = React.useState<PersistedTaskPaneState>(() =>
+    createEmptyState()
+  );
+  const currentItemKeyRef = React.useRef<string | null>(null);
+  const visibilityCleanupRef = React.useRef<(() => Promise<void>) | null>(null);
+  const isMountedRef = React.useRef<boolean>(false);
 
+  const applyStateUpdate = React.useCallback(
+    (updater: (previous: PersistedTaskPaneState) => PersistedTaskPaneState) => {
+      const targetKey = currentItemKeyRef.current;
+      setViewState((previous) => {
+        const next = updater(previous);
 
-    return (
-        <div className={styles.root}>
-            <Header logo="assets/logo-filled.png" title={props.title} message="Welcome"/>
-            <TextInsertion sendText={sendText}/>
-        </div>
-    );
+        if (targetKey) {
+          savePersistedState(targetKey, next).catch((error) => {
+            console.warn(`[Taskpane] Failed to persist state for key ${targetKey}.`, error);
+          });
+        }
+
+        return next;
+      });
+    },
+    []
+  );
+
+  const mergeState = React.useCallback(
+    (partial: Partial<PersistedTaskPaneState>) => {
+      applyStateUpdate((previous) => ({
+        ...previous,
+        ...partial,
+        lastUpdatedUtc: new Date().toISOString(),
+      }));
+    },
+    [applyStateUpdate]
+  );
+
+  const refreshFromCurrentItem = React.useCallback(async () => {
+    const { key } = await resolveStorageKeyForCurrentItem();
+
+    if (!isMountedRef.current) {
+      return;
+    }
+
+    if (key === null) {
+      currentItemKeyRef.current = null;
+      setViewState(createEmptyState());
+      return;
+    }
+
+    const hasChanged = currentItemKeyRef.current !== key;
+    currentItemKeyRef.current = key;
+
+    if (hasChanged) {
+      setViewState(createEmptyState());
+    }
+
+    try {
+      const storedState = await loadPersistedState(key);
+
+      if (!isMountedRef.current || currentItemKeyRef.current !== key) {
+        return;
+      }
+
+      setViewState(storedState);
+    } catch (error) {
+      console.warn(`[Taskpane] Failed to load persisted state for key ${key}.`, error);
+
+      if (isMountedRef.current && currentItemKeyRef.current === key) {
+        setViewState(createEmptyState());
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    isMountedRef.current = true;
+
+    const initialize = async () => {
+      await refreshFromCurrentItem();
+      visibilityCleanupRef.current =
+        await registerTaskpaneVisibilityHandler(refreshFromCurrentItem);
+    };
+
+    void initialize();
+
+    const mailbox = Office.context.mailbox;
+    const itemChangedHandler = () => {
+      void refreshFromCurrentItem();
+    };
+
+    if (mailbox?.addHandlerAsync) {
+      mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChangedHandler, (result) => {
+        if (result.status !== Office.AsyncResultStatus.Succeeded) {
+          console.warn("[Taskpane] Failed to register ItemChanged handler.", result.error);
+        }
+      });
+    }
+
+    return () => {
+      isMountedRef.current = false;
+
+      if (visibilityCleanupRef.current) {
+        void visibilityCleanupRef.current();
+        visibilityCleanupRef.current = null;
+      }
+
+      if (mailbox?.removeHandlerAsync) {
+        mailbox.removeHandlerAsync(
+          Office.EventType.ItemChanged,
+          { handler: itemChangedHandler },
+          (result) => {
+            if (result.status !== Office.AsyncResultStatus.Succeeded) {
+              console.warn("[Taskpane] Failed to remove ItemChanged handler.", result.error);
+            }
+          }
+        );
+      }
+    };
+  }, [refreshFromCurrentItem]);
+
+  const handleOptionalPromptChange = React.useCallback(
+    (value: string) => {
+      mergeState({ optionalPrompt: value });
+    },
+    [mergeState]
+  );
+
+  const handleOptionalPromptVisibilityChange = React.useCallback(
+    (visible: boolean) => {
+      mergeState({ isOptionalPromptVisible: visible });
+    },
+    [mergeState]
+  );
+
+  const handleSend = React.useCallback(async () => {
+    mergeState({
+      statusMessage: "Sending the current email content...",
+      pipelineResponse: null,
+    });
+
+    try {
+      const prompt = viewState.optionalPrompt.trim();
+      const response = await sendText(prompt ? prompt : undefined);
+
+      mergeState({
+        statusMessage: "Email content sent to the server.",
+        pipelineResponse: response,
+      });
+    } catch (error) {
+      console.error(error);
+      mergeState({
+        statusMessage: "We couldn't send the email content. Please try again.",
+      });
+    }
+  }, [mergeState, viewState.optionalPrompt]);
+
+  return (
+    <div className={styles.root}>
+      <Header logo="assets/logo-filled.png" title={title} message="Welcome" />
+      <TextInsertion
+        optionalPrompt={viewState.optionalPrompt}
+        onOptionalPromptChange={handleOptionalPromptChange}
+        isOptionalPromptVisible={viewState.isOptionalPromptVisible}
+        onOptionalPromptVisibilityChange={handleOptionalPromptVisibilityChange}
+        statusMessage={viewState.statusMessage}
+        pipelineResponse={viewState.pipelineResponse}
+        onSend={handleSend}
+      />
+    </div>
+  );
 };
 
 export default App;

--- a/ui/src/taskpane/helpers/mailboxItem.ts
+++ b/ui/src/taskpane/helpers/mailboxItem.ts
@@ -1,0 +1,78 @@
+/* global Office */
+
+import { getSubjectLine } from "./emailMetadata";
+import { sanitizeString } from "./sanitization";
+
+type StorageKeyResolution = {
+  key: string | null;
+  identifiers: {
+    itemId: string | null;
+    internetMessageId: string | null;
+    conversationId: string | null;
+    subject: string | null;
+  };
+};
+
+const getItemId = async (item: any): Promise<string | null> => {
+  const directId = sanitizeString(item?.itemId);
+  if (directId) {
+    return directId;
+  }
+
+  const getItemIdAsync =
+    typeof item?.getItemIdAsync === "function" ? item.getItemIdAsync.bind(item) : null;
+  if (!getItemIdAsync) {
+    return null;
+  }
+
+  return new Promise((resolve) => {
+    getItemIdAsync((asyncResult: Office.AsyncResult<string>) => {
+      if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
+        resolve(sanitizeString(asyncResult.value));
+      } else {
+        resolve(null);
+      }
+    });
+  });
+};
+
+export const resolveStorageKeyForCurrentItem = async (): Promise<StorageKeyResolution> => {
+  const mailbox = Office.context.mailbox;
+  const currentItem = mailbox?.item as any;
+
+  if (!currentItem) {
+    return {
+      key: null,
+      identifiers: {
+        itemId: null,
+        internetMessageId: null,
+        conversationId: null,
+        subject: null,
+      },
+    };
+  }
+
+  const itemId = await getItemId(currentItem);
+  const internetMessageId = sanitizeString(currentItem.internetMessageId);
+  const conversationId = sanitizeString(currentItem.conversationId);
+  const normalizedSubject = sanitizeString(currentItem.normalizedSubject);
+  const subject = normalizedSubject ?? (await getSubjectLine(currentItem));
+
+  const candidates = [
+    itemId,
+    internetMessageId,
+    conversationId,
+    subject ? `subject:${subject}` : null,
+  ];
+  const key = candidates.find((candidate) => !!candidate) ?? null;
+
+  return {
+    key,
+    identifiers: {
+      itemId,
+      internetMessageId,
+      conversationId,
+      subject: subject ?? null,
+    },
+  };
+};

--- a/ui/src/taskpane/helpers/persistence.ts
+++ b/ui/src/taskpane/helpers/persistence.ts
@@ -1,0 +1,103 @@
+/* global OfficeRuntime, console, globalThis */
+
+import type { PipelineResponse } from "../taskpane";
+
+export interface PersistedTaskPaneState {
+  optionalPrompt: string;
+  statusMessage: string;
+  pipelineResponse: PipelineResponse | null;
+  isOptionalPromptVisible: boolean;
+  lastUpdatedUtc?: string;
+}
+
+const STORAGE_NAMESPACE = "contoso-taskpane";
+
+type StorageAdapter = {
+  getItem(key: string): Promise<string | null>;
+  setItem(key: string, value: string): Promise<void>;
+  removeItem(key: string): Promise<void>;
+};
+
+const createStorageAdapter = (): StorageAdapter => {
+  const runtimeStorage = typeof OfficeRuntime !== "undefined" ? OfficeRuntime.storage : undefined;
+  const globalScope = typeof globalThis !== "undefined" ? (globalThis as any) : undefined;
+
+  if (runtimeStorage) {
+    return {
+      getItem: (key: string) => runtimeStorage.getItem(key),
+      setItem: (key: string, value: string) => runtimeStorage.setItem(key, value),
+      removeItem: (key: string) => runtimeStorage.removeItem(key),
+    };
+  }
+
+  if (globalScope?.localStorage) {
+    return {
+      getItem: async (key: string) => globalScope.localStorage.getItem(key),
+      setItem: async (key: string, value: string) => {
+        globalScope.localStorage.setItem(key, value);
+      },
+      removeItem: async (key: string) => {
+        globalScope.localStorage.removeItem(key);
+      },
+    };
+  }
+
+  const inMemory = new Map<string, string>();
+  return {
+    getItem: async (key: string) => inMemory.get(key) ?? null,
+    setItem: async (key: string, value: string) => {
+      inMemory.set(key, value);
+    },
+    removeItem: async (key: string) => {
+      inMemory.delete(key);
+    },
+  };
+};
+
+const storage = createStorageAdapter();
+
+const createDefaultState = (): PersistedTaskPaneState => ({
+  optionalPrompt: "",
+  statusMessage: "",
+  pipelineResponse: null,
+  isOptionalPromptVisible: false,
+});
+
+const buildStorageKey = (itemKey: string): string => `${STORAGE_NAMESPACE}:${itemKey}`;
+
+export const loadPersistedState = async (itemKey: string): Promise<PersistedTaskPaneState> => {
+  const storageKey = buildStorageKey(itemKey);
+  const storedValue = await storage.getItem(storageKey);
+
+  if (!storedValue) {
+    return createDefaultState();
+  }
+
+  try {
+    const parsed = JSON.parse(storedValue) as Partial<PersistedTaskPaneState>;
+    return {
+      ...createDefaultState(),
+      ...parsed,
+      pipelineResponse: parsed.pipelineResponse ?? null,
+    };
+  } catch (error) {
+    console.warn(`[Taskpane] Failed to parse persisted state for key ${itemKey}.`, error);
+    return createDefaultState();
+  }
+};
+
+export const savePersistedState = async (
+  itemKey: string,
+  state: PersistedTaskPaneState
+): Promise<void> => {
+  const storageKey = buildStorageKey(itemKey);
+  const payload = JSON.stringify(state);
+  await storage.setItem(storageKey, payload);
+};
+
+export const clearPersistedState = async (itemKey: string): Promise<void> => {
+  const storageKey = buildStorageKey(itemKey);
+  await storage.removeItem(storageKey);
+};
+
+export const createEmptyState = createDefaultState;

--- a/ui/src/taskpane/helpers/runtime.ts
+++ b/ui/src/taskpane/helpers/runtime.ts
@@ -1,0 +1,48 @@
+/* global Office, console */
+
+/**
+ * Configure the shared runtime so the add-in keeps running when the task pane closes
+ * and ensure visibility events repopulate state when the pane is reopened.
+ */
+export const enableSharedRuntimeFeatures = async (): Promise<void> => {
+  if (!Office.addin || typeof Office.addin.setStartupBehavior !== "function") {
+    return;
+  }
+
+  try {
+    await Office.addin.setStartupBehavior(Office.StartupBehavior.load);
+  } catch (error) {
+    console.warn("[Taskpane] Unable to set startup behavior to load.", error);
+  }
+};
+
+/**
+ * Registers a handler that runs whenever the task pane becomes visible again.
+ * Returns a function that can be used to remove the handler.
+ */
+export const registerTaskpaneVisibilityHandler = async (
+  onVisible: () => void | Promise<void>
+): Promise<() => Promise<void>> => {
+  if (!Office.addin || typeof Office.addin.onVisibilityModeChanged !== "function") {
+    return async () => {};
+  }
+
+  try {
+    const removeHandler = await Office.addin.onVisibilityModeChanged(async (args) => {
+      if (args.visibilityMode === Office.VisibilityMode.taskpane) {
+        await onVisible();
+      }
+    });
+
+    return async () => {
+      try {
+        await removeHandler();
+      } catch (error) {
+        console.warn("[Taskpane] Failed to deregister the visibility handler.", error);
+      }
+    };
+  } catch (error) {
+    console.warn("[Taskpane] Failed to register the visibility handler.", error);
+    return async () => {};
+  }
+};

--- a/ui/src/taskpane/index.tsx
+++ b/ui/src/taskpane/index.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./components/App";
 import { FluentProvider, webLightTheme } from "@fluentui/react-components";
+import { enableSharedRuntimeFeatures } from "./helpers/runtime";
 
 /* global document, Office, module, require, HTMLElement */
 
@@ -11,7 +12,8 @@ const rootElement: HTMLElement | null = document.getElementById("container");
 const root = rootElement ? createRoot(rootElement) : undefined;
 
 /* Render application after Office initializes */
-Office.onReady(() => {
+Office.onReady(async () => {
+  await enableSharedRuntimeFeatures();
   root?.render(
     <FluentProvider theme={webLightTheme}>
       <App title={title} />

--- a/ui/webpack.config.js
+++ b/ui/webpack.config.js
@@ -65,7 +65,7 @@ module.exports = async (env, options) => {
       new HtmlWebpackPlugin({
         filename: "taskpane.html",
         template: "./src/taskpane/taskpane.html",
-        chunks: ["polyfill", "taskpane", "react"],
+        chunks: ["polyfill", "taskpane", "commands", "react"],
       }),
       new CopyWebpackPlugin({
         patterns: [
@@ -85,11 +85,6 @@ module.exports = async (env, options) => {
             },
           },
         ],
-      }),
-      new HtmlWebpackPlugin({
-        filename: "commands.html",
-        template: "./src/commands/commands.html",
-        chunks: ["polyfill", "commands"],
       }),
       new webpack.ProvidePlugin({
         Promise: ["es6-promise", "Promise"],


### PR DESCRIPTION
## Summary
- configure the Outlook manifests and webpack build for the shared runtime so commands and the task pane execute in one long-lived session
- add mailbox item resolution and storage helpers that use OfficeRuntime storage when available and gracefully fall back to localStorage
- refactor the React task pane to persist per-item instructions, responses, and status, and to restore them when the pane is reopened or the user switches items

## Testing
- `npm run lint` *(fails: existing prettier/no-undef violations in src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a0f6757c83208b675dcbdf8be1a4