### PR TITLE
Refactor task pane state management into a dedicated hook

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -4,15 +4,7 @@ import * as React from "react";
 import { makeStyles } from "@fluentui/react-components";
 import Header from "./Header";
 import TextInsertion from "./TextInsertion";
-import { sendText } from "../taskpane";
-import {
-  createEmptyState,
-  loadPersistedState,
-  PersistedTaskPaneState,
-  savePersistedState,
-} from "../helpers/persistence";
-import { resolveStorageKeyForCurrentItem } from "../helpers/mailboxItem";
-import { registerTaskpaneVisibilityHandler } from "../helpers/runtime";
+import { useTaskPaneController } from "../hooks/useTaskPaneController";
 
 interface AppProps {
   title: string;
@@ -30,172 +22,19 @@ const useStyles = makeStyles({
 
 const App: React.FC<AppProps> = ({ title }) => {
   const styles = useStyles();
-  const [viewState, setViewState] = React.useState<PersistedTaskPaneState>(() =>
-    createEmptyState()
-  );
-  const currentItemKeyRef = React.useRef<string | null>(null);
-  const visibilityCleanupRef = React.useRef<(() => Promise<void>) | null>(null);
-  const isMountedRef = React.useRef<boolean>(false);
-
-  const applyStateUpdate = React.useCallback(
-    (updater: (previous: PersistedTaskPaneState) => PersistedTaskPaneState) => {
-      const targetKey = currentItemKeyRef.current;
-      setViewState((previous) => {
-        const next = updater(previous);
-
-        if (targetKey) {
-          savePersistedState(targetKey, next).catch((error) => {
-            console.warn(`[Taskpane] Failed to persist state for key ${targetKey}.`, error);
-          });
-        }
-
-        return next;
-      });
-    },
-    []
-  );
-
-  const mergeState = React.useCallback(
-    (partial: Partial<PersistedTaskPaneState>) => {
-      applyStateUpdate((previous) => ({
-        ...previous,
-        ...partial,
-        lastUpdatedUtc: new Date().toISOString(),
-      }));
-    },
-    [applyStateUpdate]
-  );
-
-  const refreshFromCurrentItem = React.useCallback(async () => {
-    const { key } = await resolveStorageKeyForCurrentItem();
-
-    if (!isMountedRef.current) {
-      return;
-    }
-
-    if (key === null) {
-      currentItemKeyRef.current = null;
-      setViewState(createEmptyState());
-      return;
-    }
-
-    const hasChanged = currentItemKeyRef.current !== key;
-    currentItemKeyRef.current = key;
-
-    if (hasChanged) {
-      setViewState(createEmptyState());
-    }
-
-    try {
-      const storedState = await loadPersistedState(key);
-
-      if (!isMountedRef.current || currentItemKeyRef.current !== key) {
-        return;
-      }
-
-      setViewState(storedState);
-    } catch (error) {
-      console.warn(`[Taskpane] Failed to load persisted state for key ${key}.`, error);
-
-      if (isMountedRef.current && currentItemKeyRef.current === key) {
-        setViewState(createEmptyState());
-      }
-    }
-  }, []);
-
-  React.useEffect(() => {
-    isMountedRef.current = true;
-
-    const initialize = async () => {
-      await refreshFromCurrentItem();
-      visibilityCleanupRef.current =
-        await registerTaskpaneVisibilityHandler(refreshFromCurrentItem);
-    };
-
-    void initialize();
-
-    const mailbox = Office.context.mailbox;
-    const itemChangedHandler = () => {
-      void refreshFromCurrentItem();
-    };
-
-    if (mailbox?.addHandlerAsync) {
-      mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChangedHandler, (result) => {
-        if (result.status !== Office.AsyncResultStatus.Succeeded) {
-          console.warn("[Taskpane] Failed to register ItemChanged handler.", result.error);
-        }
-      });
-    }
-
-    return () => {
-      isMountedRef.current = false;
-
-      if (visibilityCleanupRef.current) {
-        void visibilityCleanupRef.current();
-        visibilityCleanupRef.current = null;
-      }
-
-      if (mailbox?.removeHandlerAsync) {
-        mailbox.removeHandlerAsync(
-          Office.EventType.ItemChanged,
-          { handler: itemChangedHandler },
-          (result) => {
-            if (result.status !== Office.AsyncResultStatus.Succeeded) {
-              console.warn("[Taskpane] Failed to remove ItemChanged handler.", result.error);
-            }
-          }
-        );
-      }
-    };
-  }, [refreshFromCurrentItem]);
-
-  const handleOptionalPromptChange = React.useCallback(
-    (value: string) => {
-      mergeState({ optionalPrompt: value });
-    },
-    [mergeState]
-  );
-
-  const handleOptionalPromptVisibilityChange = React.useCallback(
-    (visible: boolean) => {
-      mergeState({ isOptionalPromptVisible: visible });
-    },
-    [mergeState]
-  );
-
-  const handleSend = React.useCallback(async () => {
-    mergeState({
-      statusMessage: "Sending the current email content...",
-      pipelineResponse: null,
-    });
-
-    try {
-      const prompt = viewState.optionalPrompt.trim();
-      const response = await sendText(prompt ? prompt : undefined);
-
-      mergeState({
-        statusMessage: "Email content sent to the server.",
-        pipelineResponse: response,
-      });
-    } catch (error) {
-      console.error(error);
-      mergeState({
-        statusMessage: "We couldn't send the email content. Please try again.",
-      });
-    }
-  }, [mergeState, viewState.optionalPrompt]);
+  const { state, actions } = useTaskPaneController();
 
   return (
     <div className={styles.root}>
       <Header logo="assets/logo-filled.png" title={title} message="Welcome" />
       <TextInsertion
-        optionalPrompt={viewState.optionalPrompt}
-        onOptionalPromptChange={handleOptionalPromptChange}
-        isOptionalPromptVisible={viewState.isOptionalPromptVisible}
-        onOptionalPromptVisibilityChange={handleOptionalPromptVisibilityChange}
-        statusMessage={viewState.statusMessage}
-        pipelineResponse={viewState.pipelineResponse}
-        onSend={handleSend}
+        optionalPrompt={state.optionalPrompt}
+        onOptionalPromptChange={actions.updateOptionalPrompt}
+        isOptionalPromptVisible={state.isOptionalPromptVisible}
+        onOptionalPromptVisibilityChange={actions.setOptionalPromptVisible}
+        statusMessage={state.statusMessage}
+        pipelineResponse={state.pipelineResponse}
+        onSend={actions.sendCurrentEmail}
       />
     </div>
   );

--- a/ui/src/taskpane/hooks/useTaskPaneController.ts
+++ b/ui/src/taskpane/hooks/useTaskPaneController.ts
@@ -1,0 +1,224 @@
+/* global Office, console */
+
+import * as React from "react";
+import {
+  createEmptyState,
+  loadPersistedState,
+  PersistedTaskPaneState,
+  savePersistedState,
+} from "../helpers/persistence";
+import { resolveStorageKeyForCurrentItem } from "../helpers/mailboxItem";
+import { registerTaskpaneVisibilityHandler } from "../helpers/runtime";
+import { sendText } from "../taskpane";
+
+export interface TaskPaneActions {
+  refreshFromCurrentItem: () => Promise<void>;
+  updateOptionalPrompt: (value: string) => void;
+  setOptionalPromptVisible: (visible: boolean) => void;
+  sendCurrentEmail: () => Promise<void>;
+}
+
+export interface TaskPaneController {
+  state: PersistedTaskPaneState;
+  actions: TaskPaneActions;
+}
+
+const usePersistedState = () => {
+  const [state, setState] = React.useState<PersistedTaskPaneState>(() => createEmptyState());
+  const currentItemKeyRef = React.useRef<string | null>(null);
+  const isMountedRef = React.useRef<boolean>(false);
+  const visibilityCleanupRef = React.useRef<(() => Promise<void>) | null>(null);
+  const latestStateRef = React.useRef<PersistedTaskPaneState>(state);
+
+  React.useEffect(() => {
+    latestStateRef.current = state;
+  }, [state]);
+
+  const applyStateUpdate = React.useCallback(
+    (updater: (previous: PersistedTaskPaneState) => PersistedTaskPaneState) => {
+      const targetKey = currentItemKeyRef.current;
+
+      setState((previous) => {
+        const next = updater(previous);
+
+        if (targetKey) {
+          console.debug(`[Taskpane] Persisting state for key ${targetKey}.`);
+          savePersistedState(targetKey, next).catch((error) => {
+            console.warn(`[Taskpane] Failed to persist state for key ${targetKey}.`, error);
+          });
+        } else {
+          console.debug("[Taskpane] Skipping persistence because there is no active item key.");
+        }
+
+        return next;
+      });
+    },
+    []
+  );
+
+  const mergeState = React.useCallback(
+    (partial: Partial<PersistedTaskPaneState>) => {
+      applyStateUpdate((previous) => ({
+        ...previous,
+        ...partial,
+        lastUpdatedUtc: new Date().toISOString(),
+      }));
+    },
+    [applyStateUpdate]
+  );
+
+  const refreshFromCurrentItem = React.useCallback(async () => {
+    console.info("[Taskpane] Refreshing task pane state for the current mailbox item.");
+    const { key } = await resolveStorageKeyForCurrentItem();
+
+    if (!isMountedRef.current) {
+      console.debug("[Taskpane] Component is not mounted. Aborting refresh.");
+      return;
+    }
+
+    if (key === null) {
+      console.info("[Taskpane] No mailbox item detected. Resetting state to defaults.");
+      currentItemKeyRef.current = null;
+      setState(createEmptyState());
+      return;
+    }
+
+    const hasChanged = currentItemKeyRef.current !== key;
+    currentItemKeyRef.current = key;
+
+    if (hasChanged) {
+      console.info(`[Taskpane] Mailbox item changed. Loading persisted state for key ${key}.`);
+      setState(createEmptyState());
+    } else {
+      console.debug(`[Taskpane] Mailbox item key ${key} unchanged. Using existing state.`);
+    }
+
+    try {
+      const storedState = await loadPersistedState(key);
+
+      if (!isMountedRef.current || currentItemKeyRef.current !== key) {
+        console.debug("[Taskpane] Component unmounted or item changed before state load finished.");
+        return;
+      }
+
+      console.info(`[Taskpane] Persisted state loaded for key ${key}.`);
+      setState(storedState);
+    } catch (error) {
+      console.warn(`[Taskpane] Failed to load persisted state for key ${key}.`, error);
+
+      if (isMountedRef.current && currentItemKeyRef.current === key) {
+        console.info("[Taskpane] Falling back to empty state after load failure.");
+        setState(createEmptyState());
+      }
+    }
+  }, []);
+
+  React.useEffect(() => {
+    isMountedRef.current = true;
+    console.info("[Taskpane] Task pane mounted. Initializing lifecycle handlers.");
+
+    const initialize = async () => {
+      await refreshFromCurrentItem();
+      visibilityCleanupRef.current =
+        await registerTaskpaneVisibilityHandler(refreshFromCurrentItem);
+    };
+
+    void initialize();
+
+    const mailbox = Office.context.mailbox;
+    const itemChangedHandler = () => {
+      console.info("[Taskpane] Office item changed event received. Triggering refresh.");
+      void refreshFromCurrentItem();
+    };
+
+    if (mailbox?.addHandlerAsync) {
+      mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChangedHandler, (result) => {
+        if (result.status !== Office.AsyncResultStatus.Succeeded) {
+          console.warn("[Taskpane] Failed to register ItemChanged handler.", result.error);
+        } else {
+          console.info("[Taskpane] ItemChanged handler registered.");
+        }
+      });
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      console.info("[Taskpane] Task pane unmounted. Cleaning up handlers.");
+
+      if (visibilityCleanupRef.current) {
+        void visibilityCleanupRef.current();
+        visibilityCleanupRef.current = null;
+      }
+
+      if (mailbox?.removeHandlerAsync) {
+        mailbox.removeHandlerAsync(
+          Office.EventType.ItemChanged,
+          { handler: itemChangedHandler },
+          (result) => {
+            if (result.status !== Office.AsyncResultStatus.Succeeded) {
+              console.warn("[Taskpane] Failed to remove ItemChanged handler.", result.error);
+            } else {
+              console.info("[Taskpane] ItemChanged handler removed.");
+            }
+          }
+        );
+      }
+    };
+  }, [refreshFromCurrentItem]);
+
+  const updateOptionalPrompt = React.useCallback(
+    (value: string) => {
+      console.debug("[Taskpane] Updating optional prompt.");
+      mergeState({ optionalPrompt: value });
+    },
+    [mergeState]
+  );
+
+  const setOptionalPromptVisible = React.useCallback(
+    (visible: boolean) => {
+      console.debug(`[Taskpane] Setting optional prompt visibility to ${visible}.`);
+      mergeState({ isOptionalPromptVisible: visible });
+    },
+    [mergeState]
+  );
+
+  const sendCurrentEmail = React.useCallback(async () => {
+    console.info("[Taskpane] Initiating send workflow for current email content.");
+    mergeState({
+      statusMessage: "Sending the current email content...",
+      pipelineResponse: null,
+    });
+
+    try {
+      const prompt = latestStateRef.current.optionalPrompt.trim();
+      const response = await sendText(prompt ? prompt : undefined);
+
+      console.info("[Taskpane] Email content successfully sent to the logging service.");
+      mergeState({
+        statusMessage: "Email content sent to the server.",
+        pipelineResponse: response,
+      });
+    } catch (error) {
+      console.error("[Taskpane] Failed to send email content.", error);
+      mergeState({
+        statusMessage: "We couldn't send the email content. Please try again.",
+      });
+    }
+  }, [mergeState]);
+
+  const actions: TaskPaneActions = React.useMemo(
+    () => ({
+      refreshFromCurrentItem,
+      updateOptionalPrompt,
+      setOptionalPromptVisible,
+      sendCurrentEmail,
+    }),
+    [refreshFromCurrentItem, sendCurrentEmail, setOptionalPromptVisible, updateOptionalPrompt]
+  );
+
+  return { state, actions };
+};
+
+export const useTaskPaneController = (): TaskPaneController => {
+  return usePersistedState();
+};


### PR DESCRIPTION
## Summary
- extract task pane state, persistence, and Office lifecycle coordination into a dedicated React hook
- simplify the App component to wire the controller into presentation components
- add structured logging around refresh, persistence, and send workflows for easier diagnostics

## Testing
- npm run lint *(fails: existing prettier/no-undef violations in src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0a91336a883208d6fd2a8ce7bd636