### PR TITLE
Handle task pane responses for background sends

### DIFF
--- a/ui/src/taskpane/helpers/persistence.ts
+++ b/ui/src/taskpane/helpers/persistence.ts
@@ -100,4 +100,24 @@ export const clearPersistedState = async (itemKey: string): Promise<void> => {
   await storage.removeItem(storageKey);
 };
 
+export const updatePersistedState = async (
+  itemKey: string,
+  partial: Partial<PersistedTaskPaneState>
+): Promise<PersistedTaskPaneState> => {
+  const currentState = await loadPersistedState(itemKey);
+  const nextState: PersistedTaskPaneState = {
+    ...currentState,
+    ...partial,
+    pipelineResponse:
+      partial.pipelineResponse !== undefined
+        ? partial.pipelineResponse
+        : currentState.pipelineResponse ?? null,
+    lastUpdatedUtc: new Date().toISOString(),
+  };
+
+  await savePersistedState(itemKey, nextState);
+
+  return nextState;
+};
+
 export const createEmptyState = createDefaultState;


### PR DESCRIPTION
## Summary
- add a persistence helper that can merge partial task pane state updates for a specific mailbox item
- update the task pane controller to store send results against the originating item even after navigation

## Testing
- npm run lint *(fails: existing Prettier and no-undef violations in ui/src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b1a45a08832090a489ffecf23f4c