### PR TITLE
Persist send progress across mailbox items

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -35,6 +35,7 @@ const App: React.FC<AppProps> = ({ title }) => {
         statusMessage={state.statusMessage}
         pipelineResponse={state.pipelineResponse}
         onSend={actions.sendCurrentEmail}
+        isSending={state.isSending}
       />
     </div>
   );

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Button,
   Field,
@@ -18,6 +18,7 @@ interface TextInsertionProps {
   statusMessage: string;
   pipelineResponse: PipelineResponse | null;
   onSend: () => Promise<void>;
+  isSending: boolean;
 }
 
 const useStyles = makeStyles({
@@ -80,16 +81,15 @@ const useStyles = makeStyles({
 });
 
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
-  const [isSending, setIsSending] = useState<boolean>(false);
-
   const handleTextSend = async () => {
+    if (props.isSending) {
+      return;
+    }
+
     try {
-      setIsSending(true);
       await props.onSend();
     } catch (error) {
       console.error(error);
-    } finally {
-      setIsSending(false);
     }
   };
 
@@ -107,7 +107,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
       <div className={styles.actionsRow}>
         <Button
           appearance="secondary"
-          disabled={isSending}
+          disabled={props.isSending}
           onClick={() => props.onOptionalPromptVisibilityChange(!props.isOptionalPromptVisible)}
         >
           {props.isOptionalPromptVisible ? "Hide instructions" : "Add instructions"}
@@ -161,8 +161,8 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
           </Field>
         </div>
       ) : null}
-      <Button appearance="primary" disabled={isSending} size="large" onClick={handleTextSend}>
-        {isSending ? "Sending..." : "Send email content"}
+      <Button appearance="primary" disabled={props.isSending} size="large" onClick={handleTextSend}>
+        {props.isSending ? "Sending..." : "Send email content"}
       </Button>
     </div>
   );

--- a/ui/src/taskpane/helpers/persistence.ts
+++ b/ui/src/taskpane/helpers/persistence.ts
@@ -7,6 +7,7 @@ export interface PersistedTaskPaneState {
   statusMessage: string;
   pipelineResponse: PipelineResponse | null;
   isOptionalPromptVisible: boolean;
+  isSending: boolean;
   lastUpdatedUtc?: string;
 }
 
@@ -61,6 +62,7 @@ const createDefaultState = (): PersistedTaskPaneState => ({
   statusMessage: "",
   pipelineResponse: null,
   isOptionalPromptVisible: false,
+  isSending: false,
 });
 
 const buildStorageKey = (itemKey: string): string => `${STORAGE_NAMESPACE}:${itemKey}`;
@@ -79,6 +81,7 @@ export const loadPersistedState = async (itemKey: string): Promise<PersistedTask
       ...createDefaultState(),
       ...parsed,
       pipelineResponse: parsed.pipelineResponse ?? null,
+      isSending: parsed.isSending ?? false,
     };
   } catch (error) {
     console.warn(`[Taskpane] Failed to parse persisted state for key ${itemKey}.`, error);
@@ -111,7 +114,9 @@ export const updatePersistedState = async (
     pipelineResponse:
       partial.pipelineResponse !== undefined
         ? partial.pipelineResponse
-        : currentState.pipelineResponse ?? null,
+        : (currentState.pipelineResponse ?? null),
+    isSending:
+      partial.isSending !== undefined ? partial.isSending : (currentState.isSending ?? false),
     lastUpdatedUtc: new Date().toISOString(),
   };
 

--- a/ui/src/taskpane/hooks/useTaskPaneController.ts
+++ b/ui/src/taskpane/hooks/useTaskPaneController.ts
@@ -211,9 +211,15 @@ const usePersistedState = () => {
     console.info("[Taskpane] Initiating send workflow for current email content.");
     const targetKey = currentItemKeyRef.current;
 
+    if (latestStateRef.current.isSending) {
+      console.info("[Taskpane] Send request ignored because another send is already in progress.");
+      return;
+    }
+
     mergeState({
       statusMessage: "Sending the current email content...",
       pipelineResponse: null,
+      isSending: true,
     });
 
     try {
@@ -224,11 +230,13 @@ const usePersistedState = () => {
       await applyStateForKey(targetKey, {
         statusMessage: "Email content sent to the server.",
         pipelineResponse: response,
+        isSending: false,
       });
     } catch (error) {
       console.error("[Taskpane] Failed to send email content.", error);
       await applyStateForKey(targetKey, {
         statusMessage: "We couldn't send the email content. Please try again.",
+        isSending: false,
       });
     }
   }, [applyStateForKey, mergeState]);


### PR DESCRIPTION
## Summary
- persist the send-progress flag in the task pane's saved state so each mailbox item remembers whether a request is pending
- guard the send workflow to keep only one request active per item and clear the pending flag when the server responds
- surface the pending flag in the UI so buttons stay disabled and the user sees a "Sending..." label while the service is still processing

## Testing
- npm run lint *(fails: existing prettier/no-undef issues in ui/src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e0b735cd7c8320b0769e71c64c8e7a