### PR TITLE
Persist task pane sending state across navigation

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -34,6 +34,7 @@ const App: React.FC<AppProps> = ({ title }) => {
         onOptionalPromptVisibilityChange={actions.setOptionalPromptVisible}
         statusMessage={state.statusMessage}
         pipelineResponse={state.pipelineResponse}
+        isSending={state.isSending}
         onSend={actions.sendCurrentEmail}
       />
     </div>

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Button,
   Field,
@@ -17,6 +17,7 @@ interface TextInsertionProps {
   onOptionalPromptVisibilityChange: (visible: boolean) => void;
   statusMessage: string;
   pipelineResponse: PipelineResponse | null;
+  isSending: boolean;
   onSend: () => Promise<void>;
 }
 
@@ -80,16 +81,11 @@ const useStyles = makeStyles({
 });
 
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
-  const [isSending, setIsSending] = useState<boolean>(false);
-
   const handleTextSend = async () => {
     try {
-      setIsSending(true);
       await props.onSend();
     } catch (error) {
       console.error(error);
-    } finally {
-      setIsSending(false);
     }
   };
 
@@ -107,7 +103,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
       <div className={styles.actionsRow}>
         <Button
           appearance="secondary"
-          disabled={isSending}
+          disabled={props.isSending}
           onClick={() => props.onOptionalPromptVisibilityChange(!props.isOptionalPromptVisible)}
         >
           {props.isOptionalPromptVisible ? "Hide instructions" : "Add instructions"}
@@ -161,8 +157,8 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
           </Field>
         </div>
       ) : null}
-      <Button appearance="primary" disabled={isSending} size="large" onClick={handleTextSend}>
-        {isSending ? "Sending..." : "Send email content"}
+      <Button appearance="primary" disabled={props.isSending} size="large" onClick={handleTextSend}>
+        {props.isSending ? "Sending..." : "Send email content"}
       </Button>
     </div>
   );

--- a/ui/src/taskpane/helpers/persistence.ts
+++ b/ui/src/taskpane/helpers/persistence.ts
@@ -7,6 +7,8 @@ export interface PersistedTaskPaneState {
   statusMessage: string;
   pipelineResponse: PipelineResponse | null;
   isOptionalPromptVisible: boolean;
+  isSending: boolean;
+  pendingRequestId: string | null;
   lastUpdatedUtc?: string;
 }
 
@@ -61,6 +63,8 @@ const createDefaultState = (): PersistedTaskPaneState => ({
   statusMessage: "",
   pipelineResponse: null,
   isOptionalPromptVisible: false,
+  isSending: false,
+  pendingRequestId: null,
 });
 
 const buildStorageKey = (itemKey: string): string => `${STORAGE_NAMESPACE}:${itemKey}`;
@@ -79,6 +83,8 @@ export const loadPersistedState = async (itemKey: string): Promise<PersistedTask
       ...createDefaultState(),
       ...parsed,
       pipelineResponse: parsed.pipelineResponse ?? null,
+      isSending: parsed.isSending ?? false,
+      pendingRequestId: parsed.pendingRequestId ?? null,
     };
   } catch (error) {
     console.warn(`[Taskpane] Failed to parse persisted state for key ${itemKey}.`, error);
@@ -111,7 +117,13 @@ export const updatePersistedState = async (
     pipelineResponse:
       partial.pipelineResponse !== undefined
         ? partial.pipelineResponse
-        : currentState.pipelineResponse ?? null,
+        : (currentState.pipelineResponse ?? null),
+    isSending:
+      partial.isSending !== undefined ? partial.isSending : (currentState.isSending ?? false),
+    pendingRequestId:
+      partial.pendingRequestId !== undefined
+        ? partial.pendingRequestId
+        : (currentState.pendingRequestId ?? null),
     lastUpdatedUtc: new Date().toISOString(),
   };
 


### PR DESCRIPTION
## Summary
- persist the task pane's sending status and request identifier in storage so background responses update the correct email
- update the controller and UI to restore in-progress operations when navigating away and back to a message

## Testing
- npm run lint *(fails: existing prettier/no-undef violations in src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e154092c3c8320a38ceb34edfb484a