### PR TITLE
Persist send operations across navigation

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -35,6 +35,7 @@ const App: React.FC<AppProps> = ({ title }) => {
         statusMessage={state.statusMessage}
         pipelineResponse={state.pipelineResponse}
         onSend={actions.sendCurrentEmail}
+        isSending={state.isSending}
       />
     </div>
   );

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo, useState } from "react";
+import { useMemo } from "react";
 import {
   Button,
   Field,
@@ -18,6 +18,7 @@ interface TextInsertionProps {
   statusMessage: string;
   pipelineResponse: PipelineResponse | null;
   onSend: () => Promise<void>;
+  isSending: boolean;
 }
 
 const useStyles = makeStyles({
@@ -80,16 +81,16 @@ const useStyles = makeStyles({
 });
 
 const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) => {
-  const [isSending, setIsSending] = useState<boolean>(false);
-
   const handleTextSend = async () => {
+    // Bail out if a send is already underway so we don't queue duplicate requests.
+    if (props.isSending) {
+      return;
+    }
+
     try {
-      setIsSending(true);
       await props.onSend();
     } catch (error) {
       console.error(error);
-    } finally {
-      setIsSending(false);
     }
   };
 
@@ -107,7 +108,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
       <div className={styles.actionsRow}>
         <Button
           appearance="secondary"
-          disabled={isSending}
+          disabled={props.isSending}
           onClick={() => props.onOptionalPromptVisibilityChange(!props.isOptionalPromptVisible)}
         >
           {props.isOptionalPromptVisible ? "Hide instructions" : "Add instructions"}
@@ -161,8 +162,8 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
           </Field>
         </div>
       ) : null}
-      <Button appearance="primary" disabled={isSending} size="large" onClick={handleTextSend}>
-        {isSending ? "Sending..." : "Send email content"}
+      <Button appearance="primary" disabled={props.isSending} size="large" onClick={handleTextSend}>
+        {props.isSending ? "Sending..." : "Send email content"}
       </Button>
     </div>
   );

--- a/ui/src/taskpane/helpers/persistence.ts
+++ b/ui/src/taskpane/helpers/persistence.ts
@@ -7,6 +7,17 @@ export interface PersistedTaskPaneState {
   statusMessage: string;
   pipelineResponse: PipelineResponse | null;
   isOptionalPromptVisible: boolean;
+  isSending: boolean;
+  /**
+   * Tracks the identifier of the in-flight request, if any, so the UI can resume
+   * waiting when the task pane is reopened on another item.
+   */
+  activeRequestId?: string | null;
+  /**
+   * Stores the sanitized optional prompt that accompanied the pending request so
+   * retries or resumed operations reuse the exact same payload.
+   */
+  activeRequestPrompt?: string | null;
   lastUpdatedUtc?: string;
 }
 
@@ -61,6 +72,9 @@ const createDefaultState = (): PersistedTaskPaneState => ({
   statusMessage: "",
   pipelineResponse: null,
   isOptionalPromptVisible: false,
+  isSending: false,
+  activeRequestId: null,
+  activeRequestPrompt: null,
 });
 
 const buildStorageKey = (itemKey: string): string => `${STORAGE_NAMESPACE}:${itemKey}`;
@@ -79,6 +93,9 @@ export const loadPersistedState = async (itemKey: string): Promise<PersistedTask
       ...createDefaultState(),
       ...parsed,
       pipelineResponse: parsed.pipelineResponse ?? null,
+      isSending: parsed.isSending ?? false,
+      activeRequestId: parsed.activeRequestId ?? null,
+      activeRequestPrompt: parsed.activeRequestPrompt ?? null,
     };
   } catch (error) {
     console.warn(`[Taskpane] Failed to parse persisted state for key ${itemKey}.`, error);
@@ -100,20 +117,55 @@ export const clearPersistedState = async (itemKey: string): Promise<void> => {
   await storage.removeItem(storageKey);
 };
 
-export const updatePersistedState = async (
-  itemKey: string,
+export type PersistedStateUpdate =
+  | Partial<PersistedTaskPaneState>
+  | ((previous: PersistedTaskPaneState) => PersistedTaskPaneState);
+
+const mergeWithDefaults = (
+  previous: PersistedTaskPaneState,
   partial: Partial<PersistedTaskPaneState>
-): Promise<PersistedTaskPaneState> => {
-  const currentState = await loadPersistedState(itemKey);
-  const nextState: PersistedTaskPaneState = {
-    ...currentState,
+): PersistedTaskPaneState => {
+  const draft: PersistedTaskPaneState = {
+    ...previous,
     ...partial,
+  };
+
+  return {
+    ...draft,
     pipelineResponse:
       partial.pipelineResponse !== undefined
         ? partial.pipelineResponse
-        : currentState.pipelineResponse ?? null,
-    lastUpdatedUtc: new Date().toISOString(),
+        : (draft.pipelineResponse ?? null),
+    isSending: partial.isSending !== undefined ? partial.isSending : (draft.isSending ?? false),
+    activeRequestId:
+      partial.activeRequestId !== undefined
+        ? partial.activeRequestId
+        : (draft.activeRequestId ?? null),
+    activeRequestPrompt:
+      partial.activeRequestPrompt !== undefined
+        ? partial.activeRequestPrompt
+        : (draft.activeRequestPrompt ?? null),
   };
+};
+
+const normalizeUpdatedState = (candidate: PersistedTaskPaneState): PersistedTaskPaneState => ({
+  ...candidate,
+  pipelineResponse: candidate.pipelineResponse ?? null,
+  isSending: candidate.isSending ?? false,
+  activeRequestId: candidate.activeRequestId ?? null,
+  activeRequestPrompt: candidate.activeRequestPrompt ?? null,
+  lastUpdatedUtc: new Date().toISOString(),
+});
+
+export const updatePersistedState = async (
+  itemKey: string,
+  update: PersistedStateUpdate
+): Promise<PersistedTaskPaneState> => {
+  const currentState = await loadPersistedState(itemKey);
+
+  const nextState = normalizeUpdatedState(
+    typeof update === "function" ? update(currentState) : mergeWithDefaults(currentState, update)
+  );
 
   await savePersistedState(itemKey, nextState);
 

--- a/ui/src/taskpane/helpers/sendOperations.ts
+++ b/ui/src/taskpane/helpers/sendOperations.ts
@@ -1,0 +1,220 @@
+/* global console, setTimeout, clearTimeout, globalThis */
+
+import type { PipelineResponse } from "../taskpane";
+
+/**
+ * Tracks long-running send operations across task pane lifecycles.
+ *
+ * When a user navigates away from the message or closes the pane we can lose the
+ * React component tree, but the shared runtime remains loaded. By keeping the
+ * operation registry on the global scope we can reconnect to requests after the
+ * UI remounts and continue processing completions.
+ */
+
+type OperationStatus = "pending" | "succeeded" | "failed";
+
+type OperationSubscriber = {
+  onSuccess?: (response: PipelineResponse) => void;
+  onError?: (error: unknown) => void;
+};
+
+interface OperationRecord {
+  requestId: string;
+  executor: () => Promise<PipelineResponse>;
+  status: OperationStatus;
+  promise: Promise<PipelineResponse>;
+  result?: PipelineResponse;
+  error?: unknown;
+  subscribers: Set<OperationSubscriber>;
+  retryCount: number;
+  retryTimer: ReturnType<typeof setTimeout> | null;
+}
+
+interface RetryScheduleResult {
+  scheduled: boolean;
+  attempt: number;
+  delayMs: number;
+}
+
+const GLOBAL_REGISTRY_KEY = "__contoso_pendingSendOperations__";
+const MAX_RETRIES = 3;
+const BASE_RETRY_DELAY_MS = 1500;
+const MAX_RETRY_DELAY_MS = 10000;
+
+const getRegistry = (): Map<string, OperationRecord> => {
+  const globalScope = globalThis as typeof globalThis & {
+    [GLOBAL_REGISTRY_KEY]?: Map<string, OperationRecord>;
+  };
+
+  if (!globalScope[GLOBAL_REGISTRY_KEY]) {
+    globalScope[GLOBAL_REGISTRY_KEY] = new Map<string, OperationRecord>();
+  }
+
+  return globalScope[GLOBAL_REGISTRY_KEY] as Map<string, OperationRecord>;
+};
+
+const notifySuccess = (record: OperationRecord, response: PipelineResponse) => {
+  for (const subscriber of Array.from(record.subscribers)) {
+    try {
+      subscriber.onSuccess?.(response);
+    } catch (error) {
+      // Subscriber errors should never break the registry pipeline; just log them.
+      console.warn("[Taskpane] Send operation success subscriber threw.", error);
+    }
+  }
+};
+
+const notifyError = (record: OperationRecord, error: unknown) => {
+  for (const subscriber of Array.from(record.subscribers)) {
+    try {
+      subscriber.onError?.(error);
+    } catch (handlerError) {
+      console.warn("[Taskpane] Send operation error subscriber threw.", handlerError);
+    }
+  }
+};
+
+const clearRetryTimer = (record: OperationRecord) => {
+  if (record.retryTimer) {
+    clearTimeout(record.retryTimer);
+    record.retryTimer = null;
+  }
+};
+
+const runOperation = (record: OperationRecord) => {
+  clearRetryTimer(record);
+  record.status = "pending";
+  record.error = undefined;
+  record.result = undefined;
+
+  record.promise = record
+    .executor()
+    .then((response) => {
+      record.status = "succeeded";
+      record.result = response;
+      record.retryCount = 0;
+      notifySuccess(record, response);
+      return response;
+    })
+    .catch((error) => {
+      record.status = "failed";
+      record.error = error;
+      notifyError(record, error);
+      return Promise.reject(error);
+    })
+    .finally(() => {
+      clearRetryTimer(record);
+
+      // Once all listeners have detached we can discard completed records so the
+      // registry cannot grow indefinitely. Pending operations stay registered so
+      // future subscribers can attach.
+      if (record.status !== "pending" && record.subscribers.size === 0) {
+        getRegistry().delete(record.requestId);
+      }
+    });
+};
+
+const createOperationRecord = (
+  requestId: string,
+  executor: () => Promise<PipelineResponse>
+): OperationRecord => {
+  const record: OperationRecord = {
+    requestId,
+    executor,
+    status: "pending",
+    promise: Promise.resolve(null as unknown as PipelineResponse),
+    subscribers: new Set(),
+    retryCount: 0,
+    retryTimer: null,
+  };
+
+  runOperation(record);
+
+  getRegistry().set(requestId, record);
+  return record;
+};
+
+const ensureOperationRecord = (
+  requestId: string,
+  executor: () => Promise<PipelineResponse>
+): OperationRecord => {
+  const registry = getRegistry();
+  const existing = registry.get(requestId);
+
+  if (existing) {
+    // Always keep the latest executor so resumed operations send the freshest
+    // payload (prompt, metadata, etc.).
+    existing.executor = executor;
+    return existing;
+  }
+
+  return createOperationRecord(requestId, executor);
+};
+
+export const attachToSendOperation = (
+  requestId: string,
+  executor: () => Promise<PipelineResponse>,
+  subscriber: OperationSubscriber
+) => {
+  const record = ensureOperationRecord(requestId, executor);
+  record.subscribers.add(subscriber);
+
+  // If the operation already completed before this subscriber attached we invoke
+  // the handler immediately so the UI can hydrate without waiting for a rerun.
+  if (record.status === "succeeded" && record.result) {
+    subscriber.onSuccess?.(record.result);
+  } else if (record.status === "failed" && record.error !== undefined) {
+    subscriber.onError?.(record.error);
+  }
+
+  const detach = () => {
+    record.subscribers.delete(subscriber);
+    if (record.subscribers.size === 0 && record.status !== "pending") {
+      getRegistry().delete(requestId);
+    }
+  };
+
+  return { detach, status: record.status, record };
+};
+
+export const scheduleSendOperationRetry = (requestId: string): RetryScheduleResult => {
+  const registry = getRegistry();
+  const record = registry.get(requestId);
+
+  if (!record || record.status !== "failed") {
+    return { scheduled: false, attempt: record?.retryCount ?? 0, delayMs: 0 };
+  }
+
+  if (record.retryCount >= MAX_RETRIES) {
+    return { scheduled: false, attempt: record.retryCount, delayMs: 0 };
+  }
+
+  clearRetryTimer(record);
+
+  const attempt = record.retryCount + 1;
+  const delayMs = Math.min(BASE_RETRY_DELAY_MS * attempt, MAX_RETRY_DELAY_MS);
+
+  record.retryCount = attempt;
+  record.retryTimer = setTimeout(() => {
+    record.retryTimer = null;
+    runOperation(record);
+  }, delayMs);
+
+  return { scheduled: true, attempt, delayMs };
+};
+
+export const clearSendOperation = (requestId: string): void => {
+  const registry = getRegistry();
+  const record = registry.get(requestId);
+
+  if (!record) {
+    return;
+  }
+
+  clearRetryTimer(record);
+  registry.delete(requestId);
+};
+
+export const MAX_SEND_OPERATION_RETRIES = MAX_RETRIES;
+
+export type { OperationRecord, OperationStatus };


### PR DESCRIPTION
## Summary
- persist the originating prompt alongside the pending request metadata so a resumed task pane reuses the correct payload
- add a shared send-operation registry that keeps requests alive, supports retry with backoff, and lets new task panes resubscribe after navigation
- wire the task pane controller to the registry so it reconnects to in-flight sends, schedules retries for transient failures, and delegates sends through the shared executor

## Testing
- npm run lint *(fails: pre-existing prettier/no-undef issues in ui/src/taskpane/helpers/emailAddress.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e154092c3c8320a38ceb34edfb484a