### PR TITLE
Enable shared runtime background retries

### DIFF
--- a/ui/manifest.xml
+++ b/ui/manifest.xml
@@ -48,6 +48,7 @@
         <Host xsi:type="MailHost">
           <DesktopFormFactor>
             <FunctionFile resid="Taskpane.Url"/>
+            <Runtime resid="Taskpane.Url"/>
             <ExtensionPoint xsi:type="MessageComposeCommandSurface">
               <OfficeTab id="TabDefault">
                 <Group id="msgComposeGroup">

--- a/ui/src/commands/commands.ts
+++ b/ui/src/commands/commands.ts
@@ -5,8 +5,12 @@
 
 /* global Office */
 
-Office.onReady(() => {
-  // If needed, Office.js is ready to be called.
+import { enableSharedRuntimeFeatures } from "../taskpane/helpers/runtime";
+import { initializeSendOperationBackgroundHost } from "../taskpane/helpers/sendOperations";
+
+Office.onReady(async () => {
+  await enableSharedRuntimeFeatures();
+  initializeSendOperationBackgroundHost();
 });
 
 /**

--- a/ui/src/taskpane/helpers/sendOperations.ts
+++ b/ui/src/taskpane/helpers/sendOperations.ts
@@ -37,6 +37,7 @@ interface RetryScheduleResult {
 }
 
 const GLOBAL_REGISTRY_KEY = "__contoso_pendingSendOperations__";
+const GLOBAL_BACKGROUND_KEY = "__contoso_sendOperationBackgroundHost__";
 const MAX_RETRIES = 3;
 const BASE_RETRY_DELAY_MS = 1500;
 const MAX_RETRY_DELAY_MS = 10000;
@@ -218,3 +219,18 @@ export const clearSendOperation = (requestId: string): void => {
 export const MAX_SEND_OPERATION_RETRIES = MAX_RETRIES;
 
 export type { OperationRecord, OperationStatus };
+
+export const initializeSendOperationBackgroundHost = (): void => {
+  const globalScope = globalThis as typeof globalThis & {
+    [GLOBAL_BACKGROUND_KEY]?: boolean;
+  };
+
+  if (globalScope[GLOBAL_BACKGROUND_KEY]) {
+    return;
+  }
+
+  globalScope[GLOBAL_BACKGROUND_KEY] = true;
+  getRegistry();
+
+  console.log("[Taskpane] Send operation background host activated.");
+};


### PR DESCRIPTION
## Summary
- opt the Outlook add-in into the shared runtime so the commands host stays active when the task pane closes
- bootstrap the send operation registry from the background commands entry point to keep retry timers alive
- expose an initializer that anchors the send operation registry on the shared runtime global scope

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2221502208320af9b3951ffc3caeb