### PR TITLE
Add cancellation support for email send workflow

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -36,6 +36,7 @@ const App: React.FC<AppProps> = ({ title }) => {
         pipelineResponse={state.pipelineResponse}
         onSend={actions.sendCurrentEmail}
         isSending={state.isSending}
+        onCancel={actions.cancelCurrentSend}
       />
     </div>
   );

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -19,6 +19,7 @@ interface TextInsertionProps {
   pipelineResponse: PipelineResponse | null;
   onSend: () => Promise<void>;
   isSending: boolean;
+  onCancel: () => Promise<void>;
 }
 
 const useStyles = makeStyles({
@@ -95,6 +96,13 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
   };
 
   const styles = useStyles();
+  const handleCancel = () => {
+    props
+      .onCancel()
+      .catch((error) => {
+        console.error(error);
+      });
+  };
   const emailResponse = useMemo(
     () => props.pipelineResponse?.assistantResponse?.emailResponse?.trim() ?? "",
     [props.pipelineResponse]
@@ -168,9 +176,16 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
           </Field>
         </div>
       ) : null}
-      <Button appearance="primary" disabled={props.isSending} size="large" onClick={handleTextSend}>
-        {props.isSending ? "Sending..." : "Send email content"}
-      </Button>
+      <div className={styles.actionsRow}>
+        <Button appearance="primary" disabled={props.isSending} size="large" onClick={handleTextSend}>
+          {props.isSending ? "Sending..." : "Send email content"}
+        </Button>
+        {props.isSending ? (
+          <Button appearance="secondary" size="large" onClick={handleCancel}>
+            Stop
+          </Button>
+        ) : null}
+      </div>
     </div>
   );
 };

--- a/ui/src/taskpane/taskpane.ts
+++ b/ui/src/taskpane/taskpane.ts
@@ -14,7 +14,10 @@ export interface PipelineResponse {
   };
 }
 
-export async function sendText(optionalPrompt?: string): Promise<PipelineResponse> {
+export async function sendText(
+  optionalPrompt?: string,
+  options?: { signal?: AbortSignal }
+): Promise<PipelineResponse> {
   // The Outlook item that is currently being viewed is available via Office.js.
   // We wrap the callback-based body.getAsync API in a Promise so it plays nicely with async/await.
   // Using a helper here keeps the flow in the try/catch block easy to read.
@@ -65,6 +68,7 @@ export async function sendText(optionalPrompt?: string): Promise<PipelineRespons
         metadata,
         optionalPrompt: optionalPrompt?.trim() || undefined,
       }),
+      signal: options?.signal,
     });
     if (!response.ok) {
       const errorText = await response.text();


### PR DESCRIPTION
## Summary
- add a Stop control to the task pane and surface cancellation through the UI
- teach the task pane controller to cancel in-flight requests and handle abort results gracefully
- propagate abort signals through the send operation registry so pending fetches can be interrupted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e2356df694832080cb67807ebcd8af