### PR TITLE
Add controls to copy or insert generated email responses

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -37,6 +37,8 @@ const App: React.FC<AppProps> = ({ title }) => {
         onSend={actions.sendCurrentEmail}
         isSending={state.isSending}
         onCancel={actions.cancelCurrentSend}
+        onCopyResponse={actions.copyResponseToClipboard}
+        onInjectResponse={actions.injectResponseIntoEmail}
       />
     </div>
   );

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { useMemo } from "react";
+import { useMemo, useCallback } from "react";
 import {
   Button,
   Field,
@@ -20,6 +20,8 @@ interface TextInsertionProps {
   onSend: () => Promise<void>;
   isSending: boolean;
   onCancel: () => Promise<void>;
+  onCopyResponse: (response: string) => Promise<void>;
+  onInjectResponse: (response: string) => Promise<void>;
 }
 
 const useStyles = makeStyles({
@@ -108,6 +110,22 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
     [props.pipelineResponse]
   );
 
+  const handleCopyResponse = useCallback(() => {
+    void props
+      .onCopyResponse(emailResponse)
+      .catch((error) => {
+        console.error(error);
+      });
+  }, [emailResponse, props]);
+
+  const handleInjectResponse = useCallback(() => {
+    void props
+      .onInjectResponse(emailResponse)
+      .catch((error) => {
+        console.error(error);
+      });
+  }, [emailResponse, props]);
+
   return (
     <div className={styles.textPromptAndInsertion}>
       <Field className={styles.instructions}>
@@ -179,6 +197,22 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
       <div className={styles.actionsRow}>
         <Button appearance="primary" disabled={props.isSending} size="large" onClick={handleTextSend}>
           {props.isSending ? "Sending..." : "Send email content"}
+        </Button>
+        <Button
+          appearance="secondary"
+          size="large"
+          disabled={!emailResponse}
+          onClick={handleCopyResponse}
+        >
+          Copy response
+        </Button>
+        <Button
+          appearance="secondary"
+          size="large"
+          disabled={!emailResponse}
+          onClick={handleInjectResponse}
+        >
+          Insert into email
         </Button>
         {props.isSending ? (
           <Button appearance="secondary" size="large" onClick={handleCancel}>

--- a/ui/src/taskpane/helpers/bodyInsertion.ts
+++ b/ui/src/taskpane/helpers/bodyInsertion.ts
@@ -1,0 +1,42 @@
+/* global Office */
+
+const encodeHtml = (value: string): string =>
+  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const convertPlainTextToHtml = (text: string): string => {
+  const escaped = encodeHtml(text);
+  const withBreaks = escaped.replace(/\r\n|\r|\n/g, "<br />");
+  return `<div>${withBreaks}</div>`;
+};
+
+export const insertResponseIntoBody = async (response: string): Promise<void> => {
+  if (!response) {
+    return;
+  }
+
+  const mailbox = Office?.context?.mailbox;
+  const currentItem = mailbox?.item;
+  const body = currentItem?.body as Office.Body | undefined;
+
+  if (!body || typeof body.setSelectedDataAsync !== "function") {
+    throw new Error(
+      "The email body can't be updated from this context. Open a draft or reply and try again."
+    );
+  }
+
+  const htmlContent = convertPlainTextToHtml(response);
+
+  await new Promise<void>((resolve, reject) => {
+    body.setSelectedDataAsync(
+      htmlContent,
+      { coercionType: Office.CoercionType.Html },
+      (asyncResult) => {
+        if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
+          resolve();
+        } else {
+          reject(asyncResult.error);
+        }
+      }
+    );
+  });
+};

--- a/ui/src/taskpane/helpers/clipboard.ts
+++ b/ui/src/taskpane/helpers/clipboard.ts
@@ -1,0 +1,34 @@
+/* global document, navigator */
+
+export const copyTextToClipboard = async (text: string): Promise<void> => {
+  if (!text) {
+    return;
+  }
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    await navigator.clipboard.writeText(text);
+    return;
+  }
+
+  if (typeof document === "undefined") {
+    throw new Error("Clipboard APIs are not available in this environment.");
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "true");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-1000px";
+  textarea.style.left = "-1000px";
+  document.body.appendChild(textarea);
+
+  textarea.select();
+  textarea.setSelectionRange(0, textarea.value.length);
+
+  const successful = document.execCommand("copy");
+  document.body.removeChild(textarea);
+
+  if (!successful) {
+    throw new Error("Copy command was rejected by the browser.");
+  }
+};


### PR DESCRIPTION
## Summary
- add copy and insert controls to the task pane response UI so users can reuse the generated reply quickly
- connect new task pane controller actions that copy the response text and inject it into the active email draft
- provide helpers for clipboard access and inserting HTML into the Outlook compose body

## Testing
- npm run lint *(fails: existing lint errors in the project)*

------
https://chatgpt.com/codex/tasks/task_e_68e23d7c4ef883208d3fb8ce7cfa0f33