### PR TITLE
Adjust task pane controls layout

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -91,6 +91,16 @@ const useStyles = makeStyles({
         gap: "12px",
         alignItems: "center",
     },
+    fullWidthButton: {
+        width: "100%",
+    },
+    stopButton: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "8px",
+    },
     primaryActionButton: {
         width: "100%",
     },
@@ -152,9 +162,17 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
             <Field className={styles.instructions}>
                 Press the button to send the body of the email you're viewing to the server.
             </Field>
+            <Field className={styles.statusField} label="Status" size="large">
+                <Textarea
+                    value={props.statusMessage}
+                    readOnly
+                    textarea={{className: styles.statusTextArea}}
+                />
+            </Field>
             <div className={styles.actionsRow}>
                 <Button
                     appearance="secondary"
+                    className={styles.fullWidthButton}
                     disabled={props.isSending}
                     onClick={() => props.onOptionalPromptVisibilityChange(!props.isOptionalPromptVisible)}
                 >
@@ -181,13 +199,6 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     />
                 </Field>
             ) : null}
-            <Field className={styles.statusField} label="Status" size="large">
-                <Textarea
-                    value={props.statusMessage}
-                    readOnly
-                    textarea={{className: styles.statusTextArea}}
-                />
-            </Field>
             <Field className={styles.responseField} label="Email response" size="large">
                 <Textarea
                     // className={styles.responseTextArea}
@@ -215,7 +226,12 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     >
                         Copy
                     </Button>
-                    <Button appearance="secondary" size="medium" onClick={handleClear}>
+                    <Button
+                        appearance="secondary"
+                        size="medium"
+                        disabled={props.isSending}
+                        onClick={handleClear}
+                    >
                         Clear
                     </Button>
                 </div>
@@ -248,7 +264,12 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     {props.isSending ? "Sending..." : emailResponse ? "Generate new response" : "Generate response"}
                 </Button>
                 {props.isSending ? (
-                    <Button appearance="secondary" size="large" onClick={handleCancel}>
+                    <Button
+                        appearance="secondary"
+                        size="large"
+                        onClick={handleCancel}
+                        className={styles.stopButton}
+                    >
                         Stop
                     </Button>
                 ) : null}


### PR DESCRIPTION
## Summary
- move the status field above the optional instructions toggle and expand the toggle to full width
- disable the clear action while sending and style the stop button with a flex row layout for better alignment

## Testing
- npm run lint *(fails: pre-existing prettier and no-undef issues in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2cef8f5088320a96460db659c8b23