### PR TITLE
feat: reorganize taskpane with Fluent UI tabs

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,10 +1,15 @@
 import * as React from "react";
-import {useMemo, useCallback} from "react";
+import {useMemo, useCallback, useEffect, useState} from "react";
 import {
     Button,
+    CounterBadge,
     Field,
     Textarea,
     TextareaOnChangeData,
+    Tab,
+    TabList,
+    TabListProps,
+    TabValue,
     tokens,
     makeStyles,
 } from "@fluentui/react-components";
@@ -77,6 +82,26 @@ const useStyles = makeStyles({
         flex: 1,
         maxWidth: "100px",
     },
+    tabContainer: {
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        flexGrow: 1,
+    },
+    tabList: {
+        width: "100%",
+    },
+    tabPanel: {
+        display: "flex",
+        flexDirection: "column",
+        gap: "12px",
+        flexGrow: 1,
+    },
+    tabLabelWithBadge: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "8px",
+    },
     linksList: {
         margin: 0,
         paddingLeft: "20px",
@@ -88,6 +113,15 @@ const useStyles = makeStyles({
     },
     linksField: {
         width: "100%",
+    },
+    linksHeading: {
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "8px",
+    },
+    emptyLinksMessage: {
+        color: tokens.colorNeutralForeground3,
+        fontStyle: "italic",
     },
     actionsRow: {
         display: "flex",
@@ -161,6 +195,49 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
             });
     }, [props]);
 
+    const [selectedTab, setSelectedTab] = useState<TabValue>(
+        props.isOptionalPromptVisible ? "instruct" : "response"
+    );
+
+    useEffect(() => {
+        setSelectedTab((current) => {
+            if (props.isOptionalPromptVisible && current !== "instruct") {
+                return "instruct";
+            }
+
+            if (!props.isOptionalPromptVisible && current === "instruct") {
+                return "response";
+            }
+
+            return current;
+        });
+    }, [props.isOptionalPromptVisible]);
+
+    useEffect(() => {
+        const shouldShowOptionalPrompt = selectedTab === "instruct";
+
+        if (props.isOptionalPromptVisible !== shouldShowOptionalPrompt) {
+            props.onOptionalPromptVisibilityChange(shouldShowOptionalPrompt);
+        }
+    }, [props.isOptionalPromptVisible, props.onOptionalPromptVisibilityChange, selectedTab]);
+
+    const handleTabSelect = useCallback<NonNullable<TabListProps["onTabSelect"]>>(
+        (_event, data) => {
+            setSelectedTab(data.value);
+        },
+        []
+    );
+
+    const sourceCitations = useMemo(
+        () =>
+            props.pipelineResponse?.assistantResponse?.sourceCitations?.filter(
+                (citation) => Boolean(citation?.url)
+            ) ?? [],
+        [props.pipelineResponse]
+    );
+
+    const linksCount = sourceCitations.length;
+
     return (
         <div className={styles.textPromptAndInsertion}>
             <Field className={styles.instructions}>
@@ -173,87 +250,122 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     textarea={{className: styles.statusTextArea}}
                 />
             </Field>
-            <div className={styles.actionsRow}>
-                <Button
-                    appearance="secondary"
-                    className={styles.fullWidthButton}
-                    disabled={props.isSending}
-                    onClick={() => props.onOptionalPromptVisibilityChange(!props.isOptionalPromptVisible)}
+            <div className={styles.tabContainer}>
+                <TabList
+                    selectedValue={selectedTab}
+                    onTabSelect={handleTabSelect}
+                    className={styles.tabList}
                 >
-                    {props.isOptionalPromptVisible ? "Hide instructions" : "Add instructions"}
-                </Button>
+                    <Tab value="response">Response</Tab>
+                    <Tab value="links">
+                        <span className={styles.tabLabelWithBadge}>
+                            Links
+                            <CounterBadge count={linksCount} size="extra-small" appearance="filled" />
+                        </span>
+                    </Tab>
+                    <Tab value="instruct">Instruct</Tab>
+                </TabList>
+                {selectedTab === "response" ? (
+                    <div className={styles.tabPanel}>
+                        <Field className={styles.responseField} label="Email response" size="large">
+                            <Textarea
+                                value={emailResponse}
+                                placeholder="The generated email response will appear here."
+                                readOnly
+                                resize="vertical"
+                                textarea={{className: styles.responseTextArea}}
+                            />
+                            <div className={styles.responseActions}>
+                                <Button
+                                    appearance="secondary"
+                                    icon={<Copy16Regular/>}
+                                    size="small"
+                                    disabled={!emailResponse}
+                                    onClick={handleCopyResponse}
+                                    className={styles.responseButtons}
+                                />
+                                <Button
+                                    appearance="secondary"
+                                    size="small"
+                                    disabled={!emailResponse}
+                                    onClick={handleInjectResponse}
+                                    className={styles.responseButtons}
+                                >
+                                    Insert
+                                </Button>
+                                <Button
+                                    appearance="secondary"
+                                    size="small"
+                                    onClick={handleClear}
+                                    className={styles.responseButtons}
+                                >
+                                    Clear
+                                </Button>
+                            </div>
+                        </Field>
+                    </div>
+                ) : null}
+                {selectedTab === "links" ? (
+                    <div className={styles.tabPanel}>
+                        <div className={styles.linksSection}>
+                            <Field
+                                className={styles.linksField}
+                                label={
+                                    <span className={styles.linksHeading}>
+                                        Links
+                                        <CounterBadge
+                                            count={linksCount}
+                                            size="extra-small"
+                                            appearance="filled"
+                                        />
+                                    </span>
+                                }
+                            >
+                                {linksCount ? (
+                                    <ul className={styles.linksList}>
+                                        {sourceCitations.map((citation, index) => (
+                                            <li key={`${citation?.url ?? "missing-url"}-${index}`}>
+                                                <a
+                                                    href={citation?.url ?? undefined}
+                                                    target="_blank"
+                                                    rel="noreferrer"
+                                                >
+                                                    {citation?.title || citation?.url}
+                                                </a>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                ) : (
+                                    <span className={styles.emptyLinksMessage}>
+                                        No links available for this response yet.
+                                    </span>
+                                )}
+                            </Field>
+                        </div>
+                    </div>
+                ) : null}
+                {selectedTab === "instruct" ? (
+                    <div className={styles.tabPanel}>
+                        <Field
+                            className={styles.optionalPromptField}
+                            label="Additional instructions"
+                            size="large"
+                            hint="Provide extra guidance for the assistant."
+                        >
+                            <Textarea
+                                value={props.optionalPrompt}
+                                onChange={(
+                                    _event: React.ChangeEvent<HTMLTextAreaElement>,
+                                    data: TextareaOnChangeData
+                                ) => props.onOptionalPromptChange(data.value)}
+                                placeholder="Add extra details or tone preferences for the generated response."
+                                resize="vertical"
+                                textarea={{className: styles.optionalPromptTextArea}}
+                            />
+                        </Field>
+                    </div>
+                ) : null}
             </div>
-            {props.isOptionalPromptVisible ? (
-                <Field
-                    className={styles.optionalPromptField}
-                    label="Additional instructions"
-                    size="large"
-                    hint="Provide extra guidance for the assistant."
-                >
-                    <Textarea
-                        // className={styles.optionalPromptTextArea}
-                        value={props.optionalPrompt}
-                        onChange={(
-                            _event: React.ChangeEvent<HTMLTextAreaElement>,
-                            data: TextareaOnChangeData
-                        ) => props.onOptionalPromptChange(data.value)}
-                        placeholder="Add extra details or tone preferences for the generated response."
-                        resize="vertical"
-                        textarea={{className: styles.optionalPromptTextArea}}
-                    />
-                </Field>
-            ) : null}
-            <Field className={styles.responseField} label="Email response" size="large">
-                <Textarea
-                    // className={styles.responseTextArea}
-                    value={emailResponse}
-                    placeholder="The generated email response will appear here."
-                    readOnly
-                    resize="vertical"
-                    textarea={{className: styles.responseTextArea}}
-                />
-                <div className={styles.responseActions}>
-                    <Button
-                        appearance="secondary"
-                        icon={<Copy16Regular/>}
-                        size="small"
-                        disabled={!emailResponse}
-                        onClick={handleCopyResponse}
-                        className={styles.responseButtons}
-                    />
-                    <Button
-                        appearance="secondary"
-                        size="small"
-                        disabled={!emailResponse}
-                        onClick={handleInjectResponse}
-                        className={styles.responseButtons}
-                    >
-                        Insert
-                    </Button>
-                    <Button appearance="secondary" size="small" onClick={handleClear} className={styles.responseButtons}>
-                        Clear
-                    </Button>
-
-
-                </div>
-            </Field>
-            {props.pipelineResponse?.assistantResponse?.sourceCitations?.length ? (
-                <div className={styles.linksSection}>
-                    <Field className={styles.linksField} label="Links provided">
-                        <ul className={styles.linksList}>
-                            {props.pipelineResponse.assistantResponse.sourceCitations.map((citation, index) =>
-                                citation?.url ? (
-                                    <li key={`${citation.url}-${index}`}>
-                                        <a href={citation.url} target="_blank" rel="noreferrer">
-                                            {citation.title || citation.url}
-                                        </a>
-                                    </li>
-                                ) : null
-                            )}
-                        </ul>
-                    </Field>
-                </div>
-            ) : null}
             <div className={styles.actionsRow}>
                 <Button
                     appearance="primary"


### PR DESCRIPTION
## Summary
- replace the optional prompt toggle with a Fluent UI tab list that splits content into Response, Links, and Instruct sections
- display link counts with Fluent UI counter badges and surface an empty state when no citations are returned
- keep the optional prompt persistence in sync with the active tab selection while reusing the existing action buttons

## Testing
- npm run lint *(fails: pre-existing lint, Office globals not defined in helper files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2d857f0fc832084601054a1508627