### PR TITLE
Refine taskpane layout for sticky footer actions

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -18,6 +18,13 @@ const useStyles = makeStyles({
     display: "flex",
     flexDirection: "column",
   },
+  content: {
+    display: "flex",
+    flexDirection: "column",
+    flexGrow: 1,
+    minHeight: 0,
+    overflow: "hidden",
+  },
 });
 
 const App: React.FC<AppProps> = ({ title }) => {
@@ -27,20 +34,22 @@ const App: React.FC<AppProps> = ({ title }) => {
   return (
     <div className={styles.root}>
       <Header logo="assets/logo-filled.png" title={title} message="Welcome" />
-      <TextInsertion
-        optionalPrompt={state.optionalPrompt}
-        onOptionalPromptChange={actions.updateOptionalPrompt}
-        isOptionalPromptVisible={state.isOptionalPromptVisible}
-        onOptionalPromptVisibilityChange={actions.setOptionalPromptVisible}
-        statusMessage={state.statusMessage}
-        pipelineResponse={state.pipelineResponse}
-        onSend={actions.sendCurrentEmail}
-        isSending={state.isSending}
-        onCancel={actions.cancelCurrentSend}
-        onCopyResponse={actions.copyResponseToClipboard}
-        onInjectResponse={actions.injectResponseIntoEmail}
-        onClear={actions.resetTaskPaneState}
-      />
+      <div className={styles.content}>
+        <TextInsertion
+          optionalPrompt={state.optionalPrompt}
+          onOptionalPromptChange={actions.updateOptionalPrompt}
+          isOptionalPromptVisible={state.isOptionalPromptVisible}
+          onOptionalPromptVisibilityChange={actions.setOptionalPromptVisible}
+          statusMessage={state.statusMessage}
+          pipelineResponse={state.pipelineResponse}
+          onSend={actions.sendCurrentEmail}
+          isSending={state.isSending}
+          onCancel={actions.cancelCurrentSend}
+          onCopyResponse={actions.copyResponseToClipboard}
+          onInjectResponse={actions.injectResponseIntoEmail}
+          onClear={actions.resetTaskPaneState}
+        />
+      </div>
     </div>
   );
 };

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -42,6 +42,15 @@ const useStyles = makeStyles({
         width: "100%",
         boxSizing: "border-box",
         height: "100%",
+        minHeight: 0,
+    },
+    contentArea: {
+        display: "flex",
+        flexDirection: "column",
+        gap: "16px",
+        flexGrow: 1,
+        minHeight: 0,
+        overflow: "hidden",
     },
     instructions: {
         fontWeight: tokens.fontWeightSemibold,
@@ -67,11 +76,13 @@ const useStyles = makeStyles({
         display: "flex",
         flexDirection: "column",
         gap: "12px",
+        minHeight: 0,
     },
     responseTextArea: {
         width: "100%",
         flexGrow: 1,
-        minHeight: "400px",
+        minHeight: 0,
+        height: "100%",
     },
     responseActions: {
         display: "flex",
@@ -93,6 +104,8 @@ const useStyles = makeStyles({
         flexDirection: "column",
         gap: "12px",
         flexGrow: 1,
+        minHeight: 0,
+        overflow: "hidden",
     },
     tabList: {
         width: "100%",
@@ -118,6 +131,8 @@ const useStyles = makeStyles({
         flexDirection: "column",
         gap: "12px",
         flexGrow: 1,
+        minHeight: 0,
+        overflowY: "auto",
     },
     tabLabelWithBadge: {
         display: "inline-flex",
@@ -150,6 +165,9 @@ const useStyles = makeStyles({
         gap: "5px",
         alignItems: "center",
         justifyContent: "space-between",
+        marginTop: "auto",
+        paddingTop: "8px",
+        backgroundColor: tokens.colorNeutralBackground1,
     },
     fullWidthButton: {
         width: "100%",
@@ -269,17 +287,18 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
 
     return (
         <div className={styles.textPromptAndInsertion}>
-            <Field className={styles.instructions}>
-                Press the button to send the body of the email you're viewing to the server.
-            </Field>
-            <Field className={styles.statusField} label="Status" size="large">
-                <Textarea
-                    value={props.statusMessage}
-                    readOnly
-                    textarea={{className: styles.statusTextArea}}
-                />
-            </Field>
-            <div className={styles.tabContainer}>
+            <div className={styles.contentArea}>
+                <Field className={styles.instructions}>
+                    Press the button to send the body of the email you're viewing to the server.
+                </Field>
+                <Field className={styles.statusField} label="Status" size="large">
+                    <Textarea
+                        value={props.statusMessage}
+                        readOnly
+                        textarea={{className: styles.statusTextArea}}
+                    />
+                </Field>
+                <div className={styles.tabContainer}>
                 <TabList
                     selectedValue={selectedTab}
                     onTabSelect={handleTabSelect}
@@ -392,7 +411,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     </div>
                 ) : null}
             </div>
-
+            </div>
             <div className={styles.actionsRow}>
                 <Button
                     appearance="primary"


### PR DESCRIPTION
## Summary
- wrap the taskpane content in a flex container so tab content scrolls independently of the viewport
- keep the primary action bar pinned to the bottom of the pane and let the response textarea grow within the available space
- adjust the app shell to reserve flex space for the taskpane content

## Testing
- npm run lint *(fails: existing Prettier/no-undef violations in helper files)*

------
https://chatgpt.com/codex/tasks/task_e_68e2fef6b68c8320af5f3ca0d594f0c8