### PR TITLE
Ensure response view fills viewport

### DIFF
--- a/ui/src/taskpane/components/App.tsx
+++ b/ui/src/taskpane/components/App.tsx
@@ -12,7 +12,7 @@ interface AppProps {
 
 const useStyles = makeStyles({
   root: {
-    minHeight: "100vh",
+    height: "100vh",
     width: "100%",
     maxWidth: "100%",
     display: "flex",

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -77,12 +77,27 @@ const useStyles = makeStyles({
         flexDirection: "column",
         gap: "12px",
         minHeight: 0,
+        "& .fui-Field__control": {
+            display: "flex",
+            flexDirection: "column",
+            flexGrow: 1,
+            minHeight: 0,
+            width: "100%",
+        },
+    },
+    responseTextAreaRoot: {
+        display: "flex",
+        flexDirection: "column",
+        flexGrow: 1,
+        minHeight: 0,
+        width: "100%",
     },
     responseTextArea: {
         width: "100%",
         flexGrow: 1,
         minHeight: 0,
         height: "100%",
+        boxSizing: "border-box",
     },
     responseActions: {
         display: "flex",
@@ -133,6 +148,9 @@ const useStyles = makeStyles({
         flexGrow: 1,
         minHeight: 0,
         overflowY: "auto",
+    },
+    responseTabPanel: {
+        overflow: "hidden",
     },
     tabLabelWithBadge: {
         display: "inline-flex",
@@ -321,9 +339,14 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     </Tab>
                 </TabList>
                 {selectedTab === "response" ? (
-                    <div className={styles.tabPanel}>
-                        <Field className={styles.responseField} label="Email response" size="large">
+                    <div className={`${styles.tabPanel} ${styles.responseTabPanel}`}>
+                        <Field
+                            className={styles.responseField}
+                            label="Email response"
+                            size="large"
+                        >
                             <Textarea
+                                className={styles.responseTextAreaRoot}
                                 value={emailResponse}
                                 placeholder="The generated email response will appear here."
                                 readOnly


### PR DESCRIPTION
## Summary
- ensure the task pane root stretches to the full viewport height so the footer actions stay anchored
- adjust the response tab layout so its textarea expands and the action bar remains at the bottom of the pane

## Testing
- npm run build:dev

------
https://chatgpt.com/codex/tasks/task_e_68e30243905c832090d402c345a14f8f