### PR TITLE
Adjust clear action placement and link numbering

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -185,6 +185,7 @@ const useStyles = makeStyles({
     linksList: {
         margin: 0,
         paddingLeft: "20px",
+        listStyleType: "decimal",
     },
     linksSection: {
         display: "flex",
@@ -205,15 +206,12 @@ const useStyles = makeStyles({
     },
     actionsRow: {
         display: "flex",
-        gap: "5px",
+        gap: "8px",
         alignItems: "center",
-        justifyContent: "space-between",
+        justifyContent: "flex-end",
         marginTop: "auto",
         paddingTop: "8px",
         backgroundColor: tokens.colorNeutralBackground1,
-    },
-    fullWidthButton: {
-        width: "100%",
     },
     stopButton: {
         display: "flex",
@@ -223,7 +221,10 @@ const useStyles = makeStyles({
         gap: "8px",
     },
     primaryActionButton: {
-        width: "100%",
+        flexGrow: 1,
+    },
+    clearButton: {
+        whiteSpace: "nowrap",
     },
 });
 
@@ -397,14 +398,6 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                                 >
                                     Insert
                                 </Button>
-                                <Button
-                                    appearance="secondary"
-                                    size="small"
-                                    onClick={handleClear}
-                                    className={styles.responseButtons}
-                                >
-                                    Clear all
-                                </Button>
                             </div>
                         </Field>
                     </div>
@@ -416,7 +409,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                                 className={styles.linksField}
                             >
                                 {linksCount ? (
-                                    <ul className={styles.linksList}>
+                                    <ol className={styles.linksList}>
                                         {sourceCitations.map((citation, index) => (
                                             <li key={`${citation?.url ?? "missing-url"}-${index}`}>
                                                 <a
@@ -428,7 +421,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                                                 </a>
                                             </li>
                                         ))}
-                                    </ul>
+                                    </ol>
                                 ) : (
                                     <span className={styles.emptyLinksMessage}>
                                         No links available for this response yet.
@@ -481,7 +474,16 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     >
                         Stop
                     </Button>
-                ) : null}
+                ) : (
+                    <Button
+                        appearance="secondary"
+                        size="large"
+                        onClick={handleClear}
+                        className={styles.clearButton}
+                    >
+                        Clear all
+                    </Button>
+                )}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- move the clear action into the footer so it sits beside the primary response button and remains hidden while a send is in progress
- ensure the clear action is accessible from the instruct tab and tweak the footer layout spacing
- display assistant links as an ordered list so references are numbered

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e30e6a5640832082064f11c4328efe