### PR TITLE
Persist task pane visibility per item

### DIFF
--- a/ui/src/taskpane/helpers/persistence.ts
+++ b/ui/src/taskpane/helpers/persistence.ts
@@ -8,6 +8,7 @@ export interface PersistedTaskPaneState {
   pipelineResponse: PipelineResponse | null;
   isOptionalPromptVisible: boolean;
   isSending: boolean;
+  isTaskPaneOpen: boolean;
   /**
    * Tracks the identifier of the in-flight request, if any, so the UI can resume
    * waiting when the task pane is reopened on another item.
@@ -73,6 +74,7 @@ const createDefaultState = (): PersistedTaskPaneState => ({
   pipelineResponse: null,
   isOptionalPromptVisible: false,
   isSending: false,
+  isTaskPaneOpen: false,
   activeRequestId: null,
   activeRequestPrompt: null,
 });
@@ -94,6 +96,7 @@ export const loadPersistedState = async (itemKey: string): Promise<PersistedTask
       ...parsed,
       pipelineResponse: parsed.pipelineResponse ?? null,
       isSending: parsed.isSending ?? false,
+      isTaskPaneOpen: parsed.isTaskPaneOpen ?? false,
       activeRequestId: parsed.activeRequestId ?? null,
       activeRequestPrompt: parsed.activeRequestPrompt ?? null,
     };
@@ -137,6 +140,10 @@ const mergeWithDefaults = (
         ? partial.pipelineResponse
         : (draft.pipelineResponse ?? null),
     isSending: partial.isSending !== undefined ? partial.isSending : (draft.isSending ?? false),
+    isTaskPaneOpen:
+      partial.isTaskPaneOpen !== undefined
+        ? partial.isTaskPaneOpen
+        : (draft.isTaskPaneOpen ?? false),
     activeRequestId:
       partial.activeRequestId !== undefined
         ? partial.activeRequestId
@@ -152,6 +159,7 @@ const normalizeUpdatedState = (candidate: PersistedTaskPaneState): PersistedTask
   ...candidate,
   pipelineResponse: candidate.pipelineResponse ?? null,
   isSending: candidate.isSending ?? false,
+  isTaskPaneOpen: candidate.isTaskPaneOpen ?? false,
   activeRequestId: candidate.activeRequestId ?? null,
   activeRequestPrompt: candidate.activeRequestPrompt ?? null,
   lastUpdatedUtc: new Date().toISOString(),

--- a/ui/src/taskpane/helpers/runtime.ts
+++ b/ui/src/taskpane/helpers/runtime.ts
@@ -16,21 +16,38 @@ export const enableSharedRuntimeFeatures = async (): Promise<void> => {
   }
 };
 
+type TaskpaneVisibilityHandlers = {
+  onTaskpaneVisible?: () => void | Promise<void>;
+  onTaskpaneHidden?: () => void | Promise<void>;
+};
+
 /**
- * Registers a handler that runs whenever the task pane becomes visible again.
+ * Registers handlers that run whenever the task pane visibility changes.
  * Returns a function that can be used to remove the handler.
  */
 export const registerTaskpaneVisibilityHandler = async (
-  onVisible: () => void | Promise<void>
+  handlers: TaskpaneVisibilityHandlers
 ): Promise<() => Promise<void>> => {
   if (!Office.addin || typeof Office.addin.onVisibilityModeChanged !== "function") {
     return async () => {};
   }
 
+  const { onTaskpaneVisible, onTaskpaneHidden } = handlers;
+
   try {
     const removeHandler = await Office.addin.onVisibilityModeChanged(async (args) => {
-      if (args.visibilityMode === Office.VisibilityMode.taskpane) {
-        await onVisible();
+      try {
+        if (args.visibilityMode === Office.VisibilityMode.taskpane) {
+          if (onTaskpaneVisible) {
+            await onTaskpaneVisible();
+          }
+        } else if (args.visibilityMode === Office.VisibilityMode.hidden) {
+          if (onTaskpaneHidden) {
+            await onTaskpaneHidden();
+          }
+        }
+      } catch (handlerError) {
+        console.warn("[Taskpane] Visibility handler threw an error.", handlerError);
       }
     });
 
@@ -44,5 +61,17 @@ export const registerTaskpaneVisibilityHandler = async (
   } catch (error) {
     console.warn("[Taskpane] Failed to register the visibility handler.", error);
     return async () => {};
+  }
+};
+
+export const showTaskpane = async (): Promise<void> => {
+  if (!Office.addin || typeof Office.addin.showAsTaskpane !== "function") {
+    return;
+  }
+
+  try {
+    await Office.addin.showAsTaskpane();
+  } catch (error) {
+    console.warn("[Taskpane] Failed to show the task pane programmatically.", error);
   }
 };

--- a/ui/src/taskpane/hooks/useTaskPaneController.ts
+++ b/ui/src/taskpane/hooks/useTaskPaneController.ts
@@ -10,7 +10,7 @@ import {
   updatePersistedState,
 } from "../helpers/persistence";
 import { resolveStorageKeyForCurrentItem } from "../helpers/mailboxItem";
-import { registerTaskpaneVisibilityHandler } from "../helpers/runtime";
+import { registerTaskpaneVisibilityHandler, showTaskpane } from "../helpers/runtime";
 import {
   attachToSendOperation,
   cancelSendOperation,
@@ -113,6 +113,7 @@ const usePersistedState = () => {
   const currentItemKeyRef = React.useRef<string | null>(null);
   const isMountedRef = React.useRef<boolean>(false);
   const visibilityCleanupRef = React.useRef<(() => Promise<void>) | null>(null);
+  const isTaskpaneVisibleRef = React.useRef<boolean>(true);
   const latestStateRef = React.useRef<PersistedTaskPaneState>(state);
   const operationSubscriptionsRef = React.useRef<Map<string, () => void>>(new Map());
 
@@ -173,6 +174,7 @@ const usePersistedState = () => {
           ...nextState,
           pipelineResponse: nextState.pipelineResponse ?? null,
           isSending: nextState.isSending ?? false,
+          isTaskPaneOpen: nextState.isTaskPaneOpen ?? false,
           activeRequestId: nextState.activeRequestId ?? null,
           activeRequestPrompt: nextState.activeRequestPrompt ?? null,
           lastUpdatedUtc: new Date().toISOString(),
@@ -399,6 +401,14 @@ const usePersistedState = () => {
       console.info(`[Taskpane] Persisted state loaded for key ${key}.`);
       resumePendingOperationIfNeeded(key, storedState);
       setState(storedState);
+
+      if (!isTaskpaneVisibleRef.current && storedState.isTaskPaneOpen) {
+        console.info(
+          `[Taskpane] Stored state indicates the task pane should be visible for key ${key}. Attempting to show it.`
+        );
+        await showTaskpane();
+        isTaskpaneVisibleRef.current = true;
+      }
     } catch (error) {
       console.warn(`[Taskpane] Failed to load persisted state for key ${key}.`, error);
 
@@ -411,12 +421,23 @@ const usePersistedState = () => {
 
   React.useEffect(() => {
     isMountedRef.current = true;
+    isTaskpaneVisibleRef.current = true;
     console.info("[Taskpane] Task pane mounted. Initializing lifecycle handlers.");
 
     const initialize = async () => {
       await refreshFromCurrentItem();
-      visibilityCleanupRef.current =
-        await registerTaskpaneVisibilityHandler(refreshFromCurrentItem);
+      await applyStateForKey(currentItemKeyRef.current, { isTaskPaneOpen: true });
+      visibilityCleanupRef.current = await registerTaskpaneVisibilityHandler({
+        onTaskpaneVisible: async () => {
+          isTaskpaneVisibleRef.current = true;
+          await refreshFromCurrentItem();
+          await applyStateForKey(currentItemKeyRef.current, { isTaskPaneOpen: true });
+        },
+        onTaskpaneHidden: async () => {
+          isTaskpaneVisibleRef.current = false;
+          await applyStateForKey(currentItemKeyRef.current, { isTaskPaneOpen: false });
+        },
+      });
     };
 
     void initialize();
@@ -456,7 +477,7 @@ const usePersistedState = () => {
         });
       }
     };
-  }, [refreshFromCurrentItem]);
+  }, [applyStateForKey, refreshFromCurrentItem]);
 
   const updateOptionalPrompt = React.useCallback(
     (value: string) => {
@@ -637,7 +658,10 @@ const usePersistedState = () => {
     });
     operationSubscriptionsRef.current.clear();
 
-    mergeState(() => createEmptyState());
+    mergeState((previous) => ({
+      ...createEmptyState(),
+      isTaskPaneOpen: previous.isTaskPaneOpen,
+    }));
   }, [cancelSendOperation, clearSendOperation, mergeState]);
 
   const actions: TaskPaneActions = React.useMemo(


### PR DESCRIPTION
## Summary
- persist the task pane open state alongside existing per-item data
- react to visibility events to keep each item's stored preference up to date
- automatically reopen the pane for items that requested it when it is hidden

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e31f25d5ac8320acf25daf26849170