### PR TITLE
Add toast confirmations and adjust task pane spacing

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -12,6 +12,11 @@ import {
     TabValue,
     tokens,
     makeStyles,
+    Toaster,
+    useToastController,
+    Toast,
+    ToastTitle,
+    ToastBody,
 } from "@fluentui/react-components";
 import {Copy16Regular, Checkmark16Regular} from "@fluentui/react-icons";
 import {PipelineResponse} from "../taskpane";
@@ -30,6 +35,8 @@ interface TextInsertionProps {
     onInjectResponse: (response: string) => Promise<void>;
     onClear: () => Promise<void>;
 }
+
+const TOASTER_ID = "text-insertion-toaster";
 
 const useStyles = makeStyles({
     textPromptAndInsertion: {
@@ -153,6 +160,10 @@ const useStyles = makeStyles({
         marginLeft: "0px",
         marginInlineStart: "0px",
     },
+    tab: {
+        paddingTop: tokens.spacingVerticalXXS,
+        paddingBottom: tokens.spacingVerticalXXS,
+    },
     firstTab: {
         paddingLeft: "0px",
         paddingInlineStart: "0px",
@@ -210,6 +221,7 @@ const useStyles = makeStyles({
         justifyContent: "flex-end",
         marginTop: "auto",
         paddingTop: "8px",
+        paddingBottom: "4px",
         backgroundColor: tokens.colorNeutralBackground1,
     },
     stopButton: {
@@ -242,6 +254,20 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
     };
 
     const styles = useStyles();
+    const { dispatchToast } = useToastController(TOASTER_ID);
+
+    const showSuccessToast = useCallback(
+        (title: string, subtitle?: string) => {
+            dispatchToast(
+                <Toast intent="success">
+                    <ToastTitle>{title}</ToastTitle>
+                    {subtitle ? <ToastBody>{subtitle}</ToastBody> : null}
+                </Toast>,
+                { intent: "success" }
+            );
+        },
+        [dispatchToast]
+    );
     const handleCancel = () => {
         props
             .onCancel()
@@ -257,18 +283,27 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
     const handleCopyResponse = useCallback(() => {
         void props
             .onCopyResponse(emailResponse)
+            .then(() => {
+                showSuccessToast("Copied to clipboard", "The response is ready to paste anywhere.");
+            })
             .catch((error) => {
                 console.error(error);
             });
-    }, [emailResponse, props]);
+    }, [emailResponse, props, showSuccessToast]);
 
     const handleInjectResponse = useCallback(() => {
         void props
             .onInjectResponse(emailResponse)
+            .then(() => {
+                showSuccessToast(
+                    "Inserted into email",
+                    "Check your draft body for the newly added response."
+                );
+            })
             .catch((error) => {
                 console.error(error);
             });
-    }, [emailResponse, props]);
+    }, [emailResponse, props, showSuccessToast]);
 
     const handleClear = useCallback(() => {
         void props
@@ -331,6 +366,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
 
     return (
         <div className={styles.textPromptAndInsertion}>
+            <Toaster toasterId={TOASTER_ID} position="top-end" />
             <div className={styles.contentArea}>
                 <Field className={styles.instructions}>
                     Press the button to send the body of the email you're viewing to the server.
@@ -348,16 +384,16 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                         onTabSelect={handleTabSelect}
                         className={styles.tabList}
                     >
-                        <Tab value="instruct" className={styles.firstTab}>
+                        <Tab value="instruct" className={`${styles.tab} ${styles.firstTab}`}>
                             Instruct
                         </Tab>
-                        <Tab value="response">
+                        <Tab value="response" className={styles.tab}>
                             <span className={styles.tabLabelWithBadge}>
                                 Response
                                 {responseBadge}
                             </span>
                         </Tab>
-                        <Tab value="links">
+                        <Tab value="links" className={styles.tab}>
                             <span className={styles.tabLabelWithBadge}>
                                 Links
                                 <Badge appearance="tint" shape="circular" className={styles.badge}>{linksCount}</Badge>
@@ -444,7 +480,7 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                                         _event: React.ChangeEvent<HTMLTextAreaElement>,
                                         data: TextareaOnChangeData
                                     ) => props.onOptionalPromptChange(data.value)}
-                                    placeholder="Add extra details or tone preferences for the generated response."
+                                    placeholder="When you press Generate, we'll send the email message you're viewing to get an answer. Add extra details or tone preferences for the generated response. It's hooked up to web search too!"
                                     resize="vertical"
                                     className={styles.optionalPromptTextAreaRoot}
 


### PR DESCRIPTION
## Summary
- add Fluent UI toast notifications when copying or inserting generated responses
- tweak tab and action-row spacing to better align with surrounding UI
- expand the instruct tab placeholder copy with additional guidance

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e3356885d08320a9d6e8b8e4e1670c