### PR TITLE
Preserve hyperlink formatting when copying citations

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -40,6 +40,24 @@ interface TextInsertionProps {
 
 const TOASTER_ID = "text-insertion-toaster";
 
+const escapeHtml = (value: string): string =>
+    value.replace(/[&<>"']/g, (match) => {
+        switch (match) {
+            case "&":
+                return "&amp;";
+            case "<":
+                return "&lt;";
+            case ">":
+                return "&gt;";
+            case '"':
+                return "&quot;";
+            case "'":
+                return "&#39;";
+            default:
+                return match;
+        }
+    });
+
 const useStyles = makeStyles({
     textPromptAndInsertion: {
         display: "flex",
@@ -464,8 +482,21 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
             })
             .join("\n");
 
+        const htmlToCopy = selectedLinks
+            .map((citation) => {
+                const url = citation?.url ?? "";
+                const title = citation?.title?.trim() || url;
+
+                if (!url) {
+                    return escapeHtml(title);
+                }
+
+                return `<a href="${escapeHtml(url)}">${escapeHtml(title)}</a>`;
+            })
+            .join("<br />");
+
         try {
-            await copyTextToClipboard(textToCopy);
+            await copyTextToClipboard(textToCopy, htmlToCopy);
             showSuccessToast(
                 selectedLinks.length === 1
                     ? "Link copied to clipboard"

--- a/ui/src/taskpane/helpers/clipboard.ts
+++ b/ui/src/taskpane/helpers/clipboard.ts
@@ -1,18 +1,34 @@
 /* global document, navigator */
 
-export const copyTextToClipboard = async (text: string): Promise<void> => {
+export const copyTextToClipboard = async (text: string, html?: string): Promise<void> => {
   if (!text) {
     return;
   }
 
   let clipboardError: unknown = null;
 
-  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
-    try {
-      await navigator.clipboard.writeText(text);
-      return;
-    } catch (error) {
-      clipboardError = error;
+  if (typeof navigator !== "undefined" && navigator.clipboard) {
+    if (html && typeof ClipboardItem !== "undefined" && navigator.clipboard.write) {
+      try {
+        await navigator.clipboard.write([
+          new ClipboardItem({
+            "text/plain": new Blob([text], { type: "text/plain" }),
+            "text/html": new Blob([html], { type: "text/html" }),
+          }),
+        ]);
+        return;
+      } catch (error) {
+        clipboardError = error;
+      }
+    }
+
+    if (navigator.clipboard.writeText) {
+      try {
+        await navigator.clipboard.writeText(text);
+        return;
+      } catch (error) {
+        clipboardError = error;
+      }
     }
   }
 
@@ -22,6 +38,48 @@ export const copyTextToClipboard = async (text: string): Promise<void> => {
     }
 
     throw new Error("Clipboard APIs are not available in this environment.");
+  }
+
+  const selection = document.getSelection();
+  const originalRange = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null;
+
+  if (html) {
+    const container = document.createElement("div");
+    container.innerHTML = html;
+    container.setAttribute("contenteditable", "true");
+    container.style.position = "fixed";
+    container.style.pointerEvents = "none";
+    container.style.opacity = "0";
+    container.style.userSelect = "text";
+    container.style.top = "0";
+    container.style.left = "0";
+    document.body.appendChild(container);
+
+    const range = document.createRange();
+    range.selectNodeContents(container);
+
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+
+    try {
+      const successful = document.execCommand("copy");
+
+      if (!successful) {
+        throw new Error("Copy command was rejected by the browser.");
+      }
+
+      return;
+    } catch (error) {
+      clipboardError = clipboardError ?? error;
+    } finally {
+      selection?.removeAllRanges();
+
+      if (originalRange) {
+        selection?.addRange(originalRange);
+      }
+
+      document.body.removeChild(container);
+    }
   }
 
   const textarea = document.createElement("textarea");
@@ -48,6 +106,12 @@ export const copyTextToClipboard = async (text: string): Promise<void> => {
 
     throw error;
   } finally {
+    selection?.removeAllRanges();
+
+    if (originalRange) {
+      selection?.addRange(originalRange);
+    }
+
     document.body.removeChild(textarea);
   }
 };


### PR DESCRIPTION
## Summary
- update clipboard helper to support copying rich HTML content when available
- copy selected citation links as anchors so they stay clickable when pasted

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e347643b208320b0cbd89b4f8723a6