### PR TITLE
Extract optional prompt field into dedicated InstructTab component

### DIFF
--- a/ui/src/taskpane/components/InstructTab.tsx
+++ b/ui/src/taskpane/components/InstructTab.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import {memo} from "react";
+import {Field, Textarea, TextareaOnChangeData} from "@fluentui/react-components";
+
+export interface InstructTabProps {
+    optionalPrompt: string;
+    onOptionalPromptChange: (value: string) => void;
+    containerClassName: string;
+    fieldClassName: string;
+    textAreaRootClassName: string;
+    textAreaClassName: string;
+}
+
+const InstructTabComponent: React.FC<InstructTabProps> = ({
+    optionalPrompt,
+    onOptionalPromptChange,
+    containerClassName,
+    fieldClassName,
+    textAreaRootClassName,
+    textAreaClassName,
+}) => (
+    <div className={containerClassName}>
+        <Field
+            className={fieldClassName}
+            size="large"
+            hint="Provide extra guidance for the assistant."
+        >
+            <Textarea
+                value={optionalPrompt}
+                onChange={(
+                    _event: React.ChangeEvent<HTMLTextAreaElement>,
+                    data: TextareaOnChangeData
+                ) => onOptionalPromptChange(data.value)}
+                placeholder={
+                    "If you need to add any extra details or tone preferences, do so in this space right here!\n\nWhen you press 'Generate', we'll use the email you're viewing to draft a relevant reply with source links.\n\nIt's connected to the web, too!"
+                }
+                resize="vertical"
+                className={textAreaRootClassName}
+                textarea={{className: textAreaClassName}}
+            />
+        </Field>
+    </div>
+);
+
+export const InstructTab = memo(InstructTabComponent);
+
+export default InstructTab;

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -3,9 +3,6 @@ import {useMemo, useCallback, useEffect, useState} from "react";
 import {
     Button,
     Badge,
-    Field,
-    Textarea,
-    TextareaOnChangeData,
     Tab,
     TabList,
     TabListProps,
@@ -22,6 +19,7 @@ import {copyTextToClipboard} from "../helpers/clipboard";
 import {useTextInsertionToasts} from "../hooks/useTextInsertionToasts";
 import {ResponseTab} from "./ResponseTab";
 import {LinksTab} from "./LinksTab";
+import {InstructTab} from "./InstructTab";
 
 interface TextInsertionProps {
     optionalPrompt: string;
@@ -578,29 +576,14 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                         />
                     ) : null}
                     {selectedTab === "instruct" ? (
-                        <div className={styles.tabPanel}>
-                            <Field
-                                className={styles.optionalPromptField}
-                                size="large"
-                                hint="Provide extra guidance for the assistant."
-                            >
-                                <Textarea
-                                    value={props.optionalPrompt}
-                                    onChange={(
-                                        _event: React.ChangeEvent<HTMLTextAreaElement>,
-                                        data: TextareaOnChangeData
-                                    ) => props.onOptionalPromptChange(data.value)}
-                                    placeholder={
-                                        "If you need to add any extra details or tone preferences, do so in this space right here!\n\nWhen you press 'Generate', we'll use the email you're viewing to draft a relevant reply with source links.\n\nIt's connected to the web, too!"
-                                    }
-
-                                    resize="vertical"
-                                    className={styles.optionalPromptTextAreaRoot}
-
-                                    textarea={{className: styles.optionalPromptTextArea}}
-                                />
-                            </Field>
-                        </div>
+                        <InstructTab
+                            optionalPrompt={props.optionalPrompt}
+                            onOptionalPromptChange={props.onOptionalPromptChange}
+                            containerClassName={styles.tabPanel}
+                            fieldClassName={styles.optionalPromptField}
+                            textAreaRootClassName={styles.optionalPromptTextAreaRoot}
+                            textAreaClassName={styles.optionalPromptTextArea}
+                        />
                     ) : null}
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- add a dedicated `InstructTab` component for the optional prompt field
- render the new component from `TextInsertion` and pass styling hooks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5bb6747f08320aa49ef554436a37e