### PR TITLE
Refactor footer actions into dedicated component

### DIFF
--- a/ui/src/taskpane/components/FooterActions.tsx
+++ b/ui/src/taskpane/components/FooterActions.tsx
@@ -1,0 +1,95 @@
+import * as React from "react";
+import { Button, Spinner, makeStyles, tokens } from "@fluentui/react-components";
+
+interface FooterActionsProps {
+    isSending: boolean;
+    emailResponse: string;
+    onSend: () => void;
+    onCancel: () => void;
+    onClear: () => void;
+}
+
+const useStyles = makeStyles({
+    root: {
+        display: "flex",
+        gap: "8px",
+        alignItems: "center",
+        justifyContent: "flex-end",
+        marginTop: "auto",
+        paddingTop: "8px",
+        paddingBottom: "4px",
+        backgroundColor: tokens.colorNeutralBackground1,
+    },
+    primaryActionButton: {
+        flexGrow: 1,
+    },
+    primaryButtonContent: {
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: tokens.spacingHorizontalSNudge,
+        width: "100%",
+    },
+    stopButton: {
+        display: "flex",
+        flexDirection: "row",
+        alignItems: "center",
+        justifyContent: "center",
+        gap: "8px",
+    },
+    clearButton: {
+        whiteSpace: "nowrap",
+    },
+});
+
+const FooterActions: React.FC<FooterActionsProps> = ({
+    isSending,
+    emailResponse,
+    onSend,
+    onCancel,
+    onClear,
+}) => {
+    const styles = useStyles();
+
+    return (
+        <div className={styles.root}>
+            <Button
+                appearance="primary"
+                disabled={isSending}
+                size="large"
+                onClick={onSend}
+                className={styles.primaryActionButton}
+            >
+                {isSending ? (
+                    <span className={styles.primaryButtonContent}>
+                        <Spinner size="extra-tiny" />
+                        Sending...
+                    </span>
+                ) : (
+                    emailResponse ? "Try Again" : "Generate"
+                )}
+            </Button>
+            {isSending ? (
+                <Button
+                    appearance="secondary"
+                    size="large"
+                    onClick={onCancel}
+                    className={styles.stopButton}
+                >
+                    Stop
+                </Button>
+            ) : (
+                <Button
+                    appearance="secondary"
+                    size="large"
+                    onClick={onClear}
+                    className={styles.clearButton}
+                >
+                    Reset
+                </Button>
+            )}
+        </div>
+    );
+};
+
+export default FooterActions;

--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 import {useMemo, useCallback, useEffect, useState} from "react";
 import {
-    Button,
     Badge,
     Tab,
     TabList,
@@ -10,7 +9,6 @@ import {
     tokens,
     makeStyles,
     Toaster,
-    Spinner,
     mergeClasses,
 } from "@fluentui/react-components";
 import {Checkmark16Regular} from "@fluentui/react-icons";
@@ -20,6 +18,7 @@ import {useTextInsertionToasts} from "../hooks/useTextInsertionToasts";
 import {ResponseTab} from "./ResponseTab";
 import {LinksTab} from "./LinksTab";
 import {InstructTab} from "./InstructTab";
+import FooterActions from "./FooterActions";
 
 interface TextInsertionProps {
     optionalPrompt: string;
@@ -253,37 +252,6 @@ const useStyles = makeStyles({
     emptyLinksMessage: {
         color: tokens.colorNeutralForeground3,
         fontStyle: "italic",
-    },
-    actionsRow: {
-        display: "flex",
-        gap: "8px",
-        alignItems: "center",
-        justifyContent: "flex-end",
-        marginTop: "auto",
-        paddingTop: "8px",
-        paddingBottom: "4px",
-        backgroundColor: tokens.colorNeutralBackground1,
-    },
-    stopButton: {
-        display: "flex",
-        flexDirection: "row",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: "8px",
-    },
-    primaryActionButton: {
-        flexGrow: 1,
-        // background: '#2A2A2A',
-    },
-    primaryButtonContent: {
-        display: "inline-flex",
-        alignItems: "center",
-        justifyContent: "center",
-        gap: tokens.spacingHorizontalSNudge,
-        width: "100%",
-    },
-    clearButton: {
-        whiteSpace: "nowrap",
     },
 });
 
@@ -587,43 +555,13 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
                     ) : null}
                 </div>
             </div>
-            <div className={styles.actionsRow}>
-                <Button
-                    appearance="primary"
-                    disabled={props.isSending}
-                    size="large"
-                    onClick={handleTextSend}
-                    className={styles.primaryActionButton}
-                >
-                    {props.isSending ? (
-                        <span className={styles.primaryButtonContent}>
-                            <Spinner size="extra-tiny"/>
-                            Sending...
-                        </span>
-                    ) : (
-                        emailResponse ? "Try Again" : "Generate"
-                    )}
-                </Button>
-                {props.isSending ? (
-                    <Button
-                        appearance="secondary"
-                        size="large"
-                        onClick={handleCancel}
-                        className={styles.stopButton}
-                    >
-                        Stop
-                    </Button>
-                ) : (
-                    <Button
-                        appearance="secondary"
-                        size="large"
-                        onClick={handleClear}
-                        className={styles.clearButton}
-                    >
-                        Reset
-                    </Button>
-                )}
-            </div>
+            <FooterActions
+                isSending={props.isSending}
+                emailResponse={emailResponse}
+                onSend={handleTextSend}
+                onCancel={handleCancel}
+                onClear={handleClear}
+            />
         </div>
     );
 };


### PR DESCRIPTION
## Summary
- extract the Generate/Stop/Reset controls from `TextInsertion` into a new `FooterActions` component
- simplify `TextInsertion` by delegating button rendering while keeping the same handlers and layout

## Testing
- npm run lint *(fails: existing lint violations in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5bdc20f7c83208e523f06f554e116