### PR TITLE
refactor: share html formatting helpers

### DIFF
--- a/ui/src/taskpane/components/TextInsertion/hooks/useCitationSelection.ts
+++ b/ui/src/taskpane/components/TextInsertion/hooks/useCitationSelection.ts
@@ -2,26 +2,9 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { copyTextToClipboard } from "../../../helpers/clipboard";
+import { escapeHtml } from "../../../helpers/htmlFormatting";
 import { UseTextInsertionToastsReturn } from "../../../hooks/useTextInsertionToasts";
 import { PipelineResponse } from "../../../taskpane";
-
-const escapeHtml = (value: string): string =>
-  value.replace(/[&<>"']/g, (match) => {
-    switch (match) {
-      case "&":
-        return "&amp;";
-      case "<":
-        return "&lt;";
-      case ">":
-        return "&gt;";
-      case '"':
-        return "&quot;";
-      case "'":
-        return "&#39;";
-      default:
-        return match;
-    }
-  });
 
 interface UseCitationSelectionOptions {
   pipelineResponse: PipelineResponse | null;

--- a/ui/src/taskpane/helpers/bodyInsertion.ts
+++ b/ui/src/taskpane/helpers/bodyInsertion.ts
@@ -1,13 +1,6 @@
 /* global Office */
 
-const encodeHtml = (value: string): string =>
-  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-
-const convertPlainTextToHtml = (text: string): string => {
-  const escaped = encodeHtml(text);
-  const withBreaks = escaped.replace(/\r\n|\r|\n/g, "<br />");
-  return `<div>${withBreaks}</div>`;
-};
+import { convertPlainTextToHtml } from "./htmlFormatting";
 
 export const insertResponseIntoBody = async (response: string): Promise<void> => {
   if (!response) {

--- a/ui/src/taskpane/helpers/htmlFormatting.ts
+++ b/ui/src/taskpane/helpers/htmlFormatting.ts
@@ -1,0 +1,26 @@
+export const escapeHtml = (value: string): string =>
+  value.replace(/[&<>"']/g, (match) => {
+    switch (match) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      case "'":
+        return "&#39;";
+      default:
+        return match;
+    }
+  });
+
+export const encodeHtml = (value: string): string =>
+  value.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+export const convertPlainTextToHtml = (text: string): string => {
+  const escaped = encodeHtml(text);
+  const withBreaks = escaped.replace(/\r\n|\r|\n/g, "<br />");
+  return `<div>${withBreaks}</div>`;
+};


### PR DESCRIPTION
## Summary
- add a shared htmlFormatting helper that exports the existing escape, encode, and conversion functions
- update the citation selection hook and compose body insertion helper to use the shared implementations

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c1e66bac8320ac2f2d1ddcb1680c