### PR TITLE
Extract email body retrieval helper

### DIFF
--- a/ui/src/taskpane/helpers/emailBodyService.ts
+++ b/ui/src/taskpane/helpers/emailBodyService.ts
@@ -1,0 +1,29 @@
+/* global Office */
+
+/**
+ * Retrieves the body of the current mailbox item as plain text.
+ * Wraps the callback-based Office.js API in a promise so callers can use async/await.
+ */
+export function getPlainTextBody(): Promise<string> {
+    return new Promise((resolve, reject) => {
+        const mailbox = Office.context.mailbox;
+        const currentItem = mailbox?.item;
+
+        if (!currentItem) {
+            reject(
+                new Error(
+                    "Unable to access the current mailbox item. Make sure the add-in is running in an Outlook item context."
+                )
+            );
+            return;
+        }
+
+        currentItem.body.getAsync(Office.CoercionType.Text, (asyncResult: Office.AsyncResult<string>) => {
+            if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
+                resolve(asyncResult.value ?? "");
+            } else {
+                reject(asyncResult.error);
+            }
+        });
+    });
+}

--- a/ui/src/taskpane/taskpane.ts
+++ b/ui/src/taskpane/taskpane.ts
@@ -1,6 +1,7 @@
 /* global console, Office, fetch */
 
 import {buildEmailMetadata} from "./helpers/emailMetadata";
+import {getPlainTextBody} from "./helpers/emailBodyService";
 
 export interface PipelineResponse {
     message: string;
@@ -18,39 +19,10 @@ export async function sendText(
     optionalPrompt?: string,
     options?: { signal?: AbortSignal }
 ): Promise<PipelineResponse> {
-    // The Outlook item that is currently being viewed is available via Office.js.
-    // We wrap the callback-based body.getAsync API in a Promise so it plays nicely with async/await.
-    // Using a helper here keeps the flow in the try/catch block easy to read.
-    const getBodyText = (): Promise<string> =>
-        new Promise((resolve, reject) => {
-            const mailbox = Office.context.mailbox;
-            const currentItem = mailbox?.item;
-
-            if (!currentItem) {
-                reject(
-                    new Error(
-                        "Unable to access the current mailbox item. Make sure the add-in is running in an Outlook item context."
-                    )
-                );
-                return;
-            }
-
-            currentItem.body.getAsync(
-                Office.CoercionType.Text,
-                (asyncResult: Office.AsyncResult<string>) => {
-                    if (asyncResult.status === Office.AsyncResultStatus.Succeeded) {
-                        resolve(asyncResult.value ?? "");
-                    } else {
-                        reject(asyncResult.error);
-                    }
-                }
-            );
-        });
-
     try {
         console.info("[Taskpane] Generate response button pressed. Retrieving email body...");
         // Retrieve the body of the current email as plain text so it can be sent to the backend.
-        const bodyText = await getBodyText();
+        const bodyText = await getPlainTextBody();
         console.info(
             `[Taskpane] Email body retrieved (${bodyText.length} characters). Preparing to post to the logging service...`
         );


### PR DESCRIPTION
## Summary
- move the Outlook body.getAsync promise wrapper into a reusable helper
- update the taskpane sendText flow to consume the shared helper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5c717b8008320941e743d87c6f3b7