### PR TITLE
Ensure text insertion send action mirrors original logic

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -19,6 +19,7 @@ import {TabLinks} from "./TabLinks";
 import {TabInstruct} from "./TabInstruct";
 import FooterActions from "./FooterActions";
 import {useCitationSelection} from "../hooks/useCitationSelection";
+import {useTextInsertionActions} from "../hooks/useTextInsertionActions";
 
 interface TextInsertionProps {
     optionalPrompt: string;
@@ -241,82 +242,28 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
     const styles = useStyles();
     const {showSuccessToast, showErrorToast} = useToasts(TOASTER_ID);
 
-    const handleTextSend = async () => {
-        // Bail out if a send is already underway so we don't queue duplicate requests.
-        if (props.isSending) {
-            return;
-        }
-
-        try {
-            await props.onSend();
-        } catch (error) {
-            console.error(error);
-            showErrorToast(
-                "Unable to send request",
-                "Something went wrong while contacting the service. Please try again."
-            );
-        }
-    };
-    const handleCancel = () => {
-        props
-            .onCancel()
-            .catch((error) => {
-                console.error(error);
-                showErrorToast(
-                    "Unable to cancel request",
-                    "We couldn't stop the current request. Please try again."
-                );
-            });
-    };
     const emailResponse = useMemo(
         () => props.pipelineResponse?.assistantResponse?.emailResponse?.trim() ?? "",
         [props.pipelineResponse]
     );
 
-    const handleCopyResponse = useCallback(() => {
-        void props
-            .onCopyResponse(emailResponse)
-            .then(() => {
-                showSuccessToast("Copied to clipboard", "The response is ready to paste anywhere.");
-            })
-            .catch((error) => {
-                console.error(error);
-                showErrorToast(
-                    "Unable to copy response",
-                    "Check your clipboard permissions and try again."
-                );
-            });
-    }, [emailResponse, props, showErrorToast, showSuccessToast]);
-
-    const handleInjectResponse = useCallback(() => {
-        void props
-            .onInjectResponse(emailResponse)
-            .then(() => {
-                showSuccessToast(
-                    "Inserted into email",
-                    "Check your draft body for the newly added response."
-                );
-            })
-            .catch((error) => {
-                console.error(error);
-                showErrorToast(
-                    "Unable to insert response",
-                    "Please try again after confirming you have an email open."
-                );
-            });
-    }, [emailResponse, props, showErrorToast, showSuccessToast]);
-
-    const handleClear = useCallback(() => {
-        void props
-            .onClear()
-            .catch((error) => {
-                console.error(error);
-                showErrorToast(
-                    "Unable to reset",
-                    "Please try again to clear the current response."
-                );
-            });
-    }, [props, showErrorToast]);
+    const {
+        handleTextSend,
+        handleCancel,
+        handleCopyResponse,
+        handleInjectResponse,
+        handleClear,
+    } = useTextInsertionActions({
+        emailResponse,
+        isSending: props.isSending,
+        onSend: props.onSend,
+        onCancel: props.onCancel,
+        onCopyResponse: props.onCopyResponse,
+        onInjectResponse: props.onInjectResponse,
+        onClear: props.onClear,
+        showSuccessToast,
+        showErrorToast,
+    });
 
     const hasResponse = emailResponse.length > 0;
 

--- a/ui/src/taskpane/hooks/useTextInsertionActions.ts
+++ b/ui/src/taskpane/hooks/useTextInsertionActions.ts
@@ -1,0 +1,114 @@
+import {useCallback} from "react";
+import {UseTextInsertionToastsReturn} from "./useToasts";
+
+interface TextInsertionActionCallbacks {
+    isSending: boolean;
+    onSend: () => Promise<void>;
+    onCancel: () => Promise<void>;
+    onCopyResponse: (response: string) => Promise<void>;
+    onInjectResponse: (response: string) => Promise<void>;
+    onClear: () => Promise<void>;
+}
+
+interface UseTextInsertionActionsParams extends TextInsertionActionCallbacks {
+    emailResponse: string;
+    showSuccessToast: UseTextInsertionToastsReturn["showSuccessToast"];
+    showErrorToast: UseTextInsertionToastsReturn["showErrorToast"];
+}
+
+// The handlers in this hook intentionally mirror the inline implementations that
+// previously lived inside the TextInsertion component. Keeping the logic
+// unchanged provides confidence that we're only relocating orchestration code
+// rather than rewriting how the actions behave.
+export const useTextInsertionActions = ({
+    emailResponse,
+    isSending,
+    onSend,
+    onCancel,
+    onCopyResponse,
+    onInjectResponse,
+    onClear,
+    showSuccessToast,
+    showErrorToast,
+}: UseTextInsertionActionsParams) => {
+    const handleTextSend = useCallback(async () => {
+        // Bail out if a send is already underway so we don't queue duplicate requests.
+        if (isSending) {
+            return;
+        }
+
+        try {
+            await onSend();
+        } catch (error) {
+            console.error(error);
+            showErrorToast(
+                "Unable to send request",
+                "Something went wrong while contacting the service. Please try again."
+            );
+        }
+    }, [isSending, onSend, showErrorToast]);
+
+    const handleCancel = useCallback(() => {
+        void onCancel().catch((error) => {
+            console.error(error);
+            showErrorToast(
+                "Unable to cancel request",
+                "We couldn't stop the current request. Please try again."
+            );
+        });
+    }, [onCancel, showErrorToast]);
+
+    const handleCopyResponse = useCallback(() => {
+        void onCopyResponse(emailResponse)
+            .then(() => {
+                showSuccessToast(
+                    "Copied to clipboard",
+                    "The response is ready to paste anywhere."
+                );
+            })
+            .catch((error) => {
+                console.error(error);
+                showErrorToast(
+                    "Unable to copy response",
+                    "Check your clipboard permissions and try again."
+                );
+            });
+    }, [emailResponse, onCopyResponse, showErrorToast, showSuccessToast]);
+
+    const handleInjectResponse = useCallback(() => {
+        void onInjectResponse(emailResponse)
+            .then(() => {
+                showSuccessToast(
+                    "Inserted into email",
+                    "Check your draft body for the newly added response."
+                );
+            })
+            .catch((error) => {
+                console.error(error);
+                showErrorToast(
+                    "Unable to insert response",
+                    "Please try again after confirming you have an email open."
+                );
+            });
+    }, [emailResponse, onInjectResponse, showErrorToast, showSuccessToast]);
+
+    const handleClear = useCallback(() => {
+        void onClear().catch((error) => {
+            console.error(error);
+            showErrorToast(
+                "Unable to reset",
+                "Please try again to clear the current response."
+            );
+        });
+    }, [onClear, showErrorToast]);
+
+    return {
+        handleTextSend,
+        handleCancel,
+        handleCopyResponse,
+        handleInjectResponse,
+        handleClear,
+    };
+};
+
+export type UseTextInsertionActionsReturn = ReturnType<typeof useTextInsertionActions>;


### PR DESCRIPTION
## Summary
- add a useTextInsertionActions hook to centralize toast-wrapped text insertion handlers
- update the TextInsertion component to consume the new hook for send, cancel, copy, inject, and clear actions
- restore the send handler's async/await implementation inside useTextInsertionActions to match the prior component logic

## Testing
- npm run lint *(fails: existing prettier and Office global lint errors in ui/src/taskpane/taskpane.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68e5d5e97f588320ba192f624b564b5b