### PR TITLE
Refine tab hook optional prompt sync

### DIFF
--- a/ui/src/taskpane/hooks/useTabs.tsx
+++ b/ui/src/taskpane/hooks/useTabs.tsx
@@ -1,0 +1,78 @@
+import {ReactNode, useCallback, useEffect, useMemo, useState} from "react";
+import {Badge, TabListProps, TabValue} from "@fluentui/react-components";
+import {Checkmark16Regular} from "@fluentui/react-icons";
+
+export interface UseTabsOptions {
+    hasResponse: boolean;
+    isOptionalPromptVisible: boolean;
+    onOptionalPromptVisibilityChange: (visible: boolean) => void;
+    responseBadgeClassName?: string;
+    responseIconClassName?: string;
+}
+
+export interface UseTabsResult {
+    selectedTab: TabValue;
+    handleTabSelect: NonNullable<TabListProps["onTabSelect"]>;
+    responseBadge: ReactNode;
+}
+
+export const useTabs = ({
+    hasResponse,
+    isOptionalPromptVisible,
+    onOptionalPromptVisibilityChange,
+    responseBadgeClassName,
+    responseIconClassName,
+}: UseTabsOptions): UseTabsResult => {
+    const [selectedTab, setSelectedTab] = useState<TabValue>(() =>
+        hasResponse ? "response" : "instruct"
+    );
+
+    useEffect(() => {
+        setSelectedTab((current) => {
+            if (hasResponse) {
+                return "response";
+            }
+
+            if (current === "response") {
+                return "instruct";
+            }
+
+            return current;
+        });
+    }, [hasResponse]);
+
+    useEffect(() => {
+        const shouldShowOptionalPrompt = selectedTab === "instruct";
+
+        if (isOptionalPromptVisible !== shouldShowOptionalPrompt) {
+            onOptionalPromptVisibilityChange(shouldShowOptionalPrompt);
+        }
+    }, [isOptionalPromptVisible, onOptionalPromptVisibilityChange, selectedTab]);
+
+    const handleTabSelect = useCallback<NonNullable<TabListProps["onTabSelect"]>>(
+        (_event, data) => {
+            setSelectedTab(data.value);
+        },
+        []
+    );
+
+    const responseBadge = useMemo(() => (
+        hasResponse ? (
+            <Badge
+                appearance="tint"
+                shape="circular"
+                color="success"
+                className={responseBadgeClassName}
+                icon={<Checkmark16Regular className={responseIconClassName} />}
+            />
+        ) : null
+    ), [hasResponse, responseBadgeClassName, responseIconClassName]);
+
+    return {
+        selectedTab,
+        handleTabSelect,
+        responseBadge,
+    };
+};
+
+export default useTabs;


### PR DESCRIPTION
## Summary
- memoize the response badge element within `useTabs` while keeping the badge rendering identical to the component's prior implementation
- ensure the optional prompt visibility effect in `useTabs` mirrors the original `TextInsertion` dependency pattern and consume the flag by checking the selected tab in the component

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68e5de906ca08320a7fcd6c4bd7e3c44