### PR TITLE
Refactor citation selection data prep

### DIFF
--- a/ui/src/taskpane/components/TextInsertion.tsx
+++ b/ui/src/taskpane/components/TextInsertion.tsx
@@ -265,24 +265,15 @@ const TextInsertion: React.FC<TextInsertionProps> = (props: TextInsertionProps) 
 
     const hasResponse = emailResponse.length > 0;
 
-    const sourceCitations = useMemo(
-        () =>
-            props.pipelineResponse?.assistantResponse?.sourceCitations?.filter(
-                (citation) => Boolean(citation?.url)
-            ) ?? [],
-        [props.pipelineResponse]
-    );
-
-    const linksCount = sourceCitations.length;
-
     const {
+        sourceCitations,
+        linksCount,
         selectedCitationIndexes,
         selectedLinksCount,
         handleCitationSelectionChange,
         handleCopySelectedLinks,
     } = useCitationSelection({
         pipelineResponse: props.pipelineResponse,
-        sourceCitations,
         showErrorToast,
         showSuccessToast,
     });

--- a/ui/src/taskpane/hooks/useCitationSelection.ts
+++ b/ui/src/taskpane/hooks/useCitationSelection.ts
@@ -1,5 +1,5 @@
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { copyTextToClipboard } from "../helpers/clipboard";
 import { escapeHtml } from "../helpers/htmlFormatting";
@@ -8,20 +8,27 @@ import { PipelineResponse } from "../taskpane";
 
 interface UseCitationSelectionOptions {
   pipelineResponse: PipelineResponse | null;
-  sourceCitations: PipelineResponse["assistantResponse"]["sourceCitations"];
   showErrorToast: UseTextInsertionToastsReturn["showErrorToast"];
   showSuccessToast: UseTextInsertionToastsReturn["showSuccessToast"];
 }
 
 export const useCitationSelection = ({
   pipelineResponse,
-  sourceCitations,
   showErrorToast,
   showSuccessToast,
 }: UseCitationSelectionOptions) => {
+  const sourceCitations = useMemo(
+    () =>
+      pipelineResponse?.assistantResponse?.sourceCitations?.filter(
+        (citation) => Boolean(citation?.url)
+      ) ?? [],
+    [pipelineResponse]
+  );
+
   const [selectedCitationIndexes, setSelectedCitationIndexes] = useState<number[]>([]);
 
   const selectedLinksCount = selectedCitationIndexes.length;
+  const linksCount = sourceCitations.length;
 
   useEffect(() => {
     setSelectedCitationIndexes((current) =>
@@ -108,6 +115,8 @@ export const useCitationSelection = ({
   ]);
 
   return {
+    sourceCitations,
+    linksCount,
     selectedCitationIndexes,
     selectedLinksCount,
     handleCitationSelectionChange,


### PR DESCRIPTION
## Summary
- derive filtered source citations inside `useCitationSelection` to centralize data preparation
- update `TextInsertion` to consume the hook outputs instead of re-deriving counts

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e5e4f9b55083209612c1699b5b8138