### PR TITLE
Rename mailbox lifecycle hook

### DIFF
--- a/ui/src/taskpane/hooks/useMailboxLifecycleHandler.ts
+++ b/ui/src/taskpane/hooks/useMailboxLifecycleHandler.ts
@@ -1,0 +1,63 @@
+import * as React from "react";
+import { registerTaskpaneVisibilityHandler } from "../helpers/outlook-runtime";
+
+interface UseMailboxLifecycleHandlerOptions {
+  refreshFromCurrentItem: () => Promise<void>;
+  isMountedRef: React.MutableRefObject<boolean>;
+  visibilityCleanupRef: React.MutableRefObject<(() => Promise<void>) | null>;
+}
+
+export const useMailboxLifecycleHandler = ({
+  refreshFromCurrentItem,
+  isMountedRef,
+  visibilityCleanupRef,
+}: UseMailboxLifecycleHandlerOptions): void => {
+  React.useEffect(() => {
+    isMountedRef.current = true;
+    console.info("[Taskpane] Task pane mounted. Initializing lifecycle handlers.");
+
+    const initialize = async () => {
+      await refreshFromCurrentItem();
+      visibilityCleanupRef.current =
+        await registerTaskpaneVisibilityHandler(refreshFromCurrentItem);
+    };
+
+    void initialize();
+
+    const mailbox = Office.context.mailbox;
+    const itemChangedHandler = () => {
+      console.info("[Taskpane] Office item changed event received. Triggering refresh.");
+      void refreshFromCurrentItem();
+    };
+
+    if (mailbox?.addHandlerAsync) {
+      mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChangedHandler, (result) => {
+        if (result.status !== Office.AsyncResultStatus.Succeeded) {
+          console.warn("[Taskpane] Failed to register ItemChanged handler.", result.error);
+        } else {
+          console.info("[Taskpane] ItemChanged handler registered.");
+        }
+      });
+    }
+
+    return () => {
+      isMountedRef.current = false;
+      console.info("[Taskpane] Task pane unmounted. Cleaning up handlers.");
+
+      if (visibilityCleanupRef.current) {
+        void visibilityCleanupRef.current();
+        visibilityCleanupRef.current = null;
+      }
+
+      if (mailbox?.removeHandlerAsync) {
+        mailbox.removeHandlerAsync(Office.EventType.ItemChanged, (result) => {
+          if (result.status !== Office.AsyncResultStatus.Succeeded) {
+            console.warn("[Taskpane] Failed to remove ItemChanged handler.", result.error);
+          } else {
+            console.info("[Taskpane] ItemChanged handler removed.");
+          }
+        });
+      }
+    };
+  }, [refreshFromCurrentItem]);
+};

--- a/ui/src/taskpane/hooks/useTaskPaneController.ts
+++ b/ui/src/taskpane/hooks/useTaskPaneController.ts
@@ -6,12 +6,12 @@ import {
   PersistedTaskPaneState,
 } from "../helpers/outlook-persistence";
 import { resolveStorageKeyForCurrentItem } from "../helpers/outlook-mailboxItem";
-import { registerTaskpaneVisibilityHandler } from "../helpers/outlook-runtime";
 import { cancelSendOperation, clearSendOperation } from "../helpers/outlook-runtimeLogic";
 import { copyTextToClipboard } from "../helpers/clipboard";
 import { insertResponseIntoBody } from "../helpers/emailBodyInsertion";
 import { useTaskPaneStatePersistence } from "./useTaskPaneStatePersistence";
 import { useSendLifecycleHandler } from "./useSendLifecycleHandler";
+import { useMailboxLifecycleHandler } from "./useMailboxLifecycleHandler";
 import { describeError } from "../utils/outlook-errorHandling";
 
 export interface TaskPaneActions {
@@ -98,54 +98,7 @@ export const useTaskPaneController = (): TaskPaneController => {
     }
   }, [resumePendingOperationIfNeeded]);
 
-  React.useEffect(() => {
-    isMountedRef.current = true;
-    console.info("[Taskpane] Task pane mounted. Initializing lifecycle handlers.");
-
-    const initialize = async () => {
-      await refreshFromCurrentItem();
-      visibilityCleanupRef.current =
-        await registerTaskpaneVisibilityHandler(refreshFromCurrentItem);
-    };
-
-    void initialize();
-
-    const mailbox = Office.context.mailbox;
-    const itemChangedHandler = () => {
-      console.info("[Taskpane] Office item changed event received. Triggering refresh.");
-      void refreshFromCurrentItem();
-    };
-
-    if (mailbox?.addHandlerAsync) {
-      mailbox.addHandlerAsync(Office.EventType.ItemChanged, itemChangedHandler, (result) => {
-        if (result.status !== Office.AsyncResultStatus.Succeeded) {
-          console.warn("[Taskpane] Failed to register ItemChanged handler.", result.error);
-        } else {
-          console.info("[Taskpane] ItemChanged handler registered.");
-        }
-      });
-    }
-
-    return () => {
-      isMountedRef.current = false;
-      console.info("[Taskpane] Task pane unmounted. Cleaning up handlers.");
-
-      if (visibilityCleanupRef.current) {
-        void visibilityCleanupRef.current();
-        visibilityCleanupRef.current = null;
-      }
-
-      if (mailbox?.removeHandlerAsync) {
-        mailbox.removeHandlerAsync(Office.EventType.ItemChanged, (result) => {
-          if (result.status !== Office.AsyncResultStatus.Succeeded) {
-            console.warn("[Taskpane] Failed to remove ItemChanged handler.", result.error);
-          } else {
-            console.info("[Taskpane] ItemChanged handler removed.");
-          }
-        });
-      }
-    };
-  }, [refreshFromCurrentItem]);
+  useMailboxLifecycleHandler({ refreshFromCurrentItem, isMountedRef, visibilityCleanupRef });
 
   const updateOptionalPrompt = React.useCallback(
     (value: string) => {


### PR DESCRIPTION
## Summary
- rename the mailbox lifecycle hook to `useMailboxLifecycleHandler`
- update the task pane controller to import and use the renamed hook

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e6015ca3708320b48dbaec80efc549